### PR TITLE
Add child logger support and module handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # bedrock ChangeLog
 
 ### Changed
-- Add child(meta) method to loggers that has common metadata. The special
-  `module` key is used to prefix messages with `[module] ` and then removed
-  from the metadata. These adjustments may be removed in the future but are
-  necessary with the current lower level logging mechanisms.
+- Add `child(meta)` method to create a child logger with common metadata for
+  each logging call. The special `module` meta key can be used to prefix
+  messages with `[module] ` and is removed from the message details.
+  `child(name)` is a shortcut for `child({module: name})`.
 
 ## 1.4.1 - 2017-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock ChangeLog
 
+### Changed
+- Add child(meta) method to loggers that has common metadata. The special
+  `module` key is used to prefix messages with `[module] ` and then removed
+  from the metadata. These adjustments may be removed in the future but are
+  necessary with the current lower level logging mechanisms.
+
 ## 1.4.1 - 2017-02-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -693,6 +693,12 @@ logger can be retrieved via `bedrock.loggers.get('app')`. A call to
 categories (such as `app`) and the transports used by them can be configured
 via `bedrock.config`.
 
+Bedrock supports multi-level child loggers with common metadata. These are
+created with `bedrock.loggers.get('app').child({...})`. Provided metadata will
+be added to child log output. A special `module` meta name can optionally be
+used for pretty output. A shortcut for creating named module loggers is
+`bedrock.loggers.get('app').child('name')`.
+
 ### bedrock.test
 
 Bedrock comes with test support built-in. It provides a test framework based

--- a/README.md
+++ b/README.md
@@ -699,6 +699,25 @@ be added to child log output. A special `module` meta name can optionally be
 used for pretty output. A shortcut for creating named module loggers is
 `bedrock.loggers.get('app').child('name')`.
 
+Module prefix display can be controlled per-category:
+
+```js
+// get a child logger with custom module name
+let logger = bedrock.loggers.get('app').child('my-module');
+
+// message module prefix controlled with a per-category config value
+bedrock.config.loggers.app.bedrock.modulePrefix = false;
+logger.info('an info message');
+// module displayed as normal meta data:
+// 2017-06-30T12:34:56.789Z - info: an info message workerPid=1234, module=my-module
+
+// with module prefix enabled:
+bedrock.config.loggers.app.bedrock.modulePrefix = true;
+logger.info('an info message');
+// displayed as an nice message prefix:
+// 2017-06-30T12:34:56.789Z - info: [my-module] an info message workerPid=1234
+```
+
 ### bedrock.test
 
 Bedrock comes with test support built-in. It provides a test framework based

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -44,7 +44,7 @@ cc({
     //  'ConfigError');
     const cachePath = path.join(__dirname, '..', '.cache');
     if(!_warningShown.cache) {
-      loggers.get('app').error(
+      loggers.get('app').child('bedrock').error(
         `"bedrock.config.paths.cache" not set, using default: "${cachePath}"`);
       _warningShown.cache = true;
     }
@@ -373,7 +373,7 @@ function _runMaster(options) {
   // get starting script
   var script = options.script || process.argv[1];
 
-  var logger = loggers.get('app');
+  var logger = loggers.get('app').child('bedrock');
   logger.info('starting bedrock...');
 
   // setup cluster if running with istanbul coverage
@@ -447,7 +447,7 @@ function _runMaster(options) {
 }
 
 function _runWorker(startTime, done) {
-  var logger = loggers.get('app');
+  var logger = loggers.get('app').child('bedrock');
 
   // set 'ps' title
   var args = process.argv.slice(2).join(' ');

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -44,7 +44,7 @@ cc({
     //  'ConfigError');
     const cachePath = path.join(__dirname, '..', '.cache');
     if(!_warningShown.cache) {
-      loggers.get('app').child('bedrock').error(
+      loggers.get('app').error(
         `"bedrock.config.paths.cache" not set, using default: "${cachePath}"`);
       _warningShown.cache = true;
     }
@@ -373,7 +373,7 @@ function _runMaster(options) {
   // get starting script
   var script = options.script || process.argv[1];
 
-  var logger = loggers.get('app').child('bedrock');
+  var logger = loggers.get('app');
   logger.info('starting bedrock...');
 
   // setup cluster if running with istanbul coverage
@@ -447,7 +447,7 @@ function _runMaster(options) {
 }
 
 function _runWorker(startTime, done) {
-  var logger = loggers.get('app').child('bedrock');
+  var logger = loggers.get('app');
 
   // set 'ps' title
   var args = process.argv.slice(2).join(' ');

--- a/lib/config.js
+++ b/lib/config.js
@@ -77,6 +77,10 @@ config.loggers.console.silent = false;
 config.loggers.console.json = false;
 config.loggers.console.timestamp = true;
 config.loggers.console.colorize = true;
+// bedrock options
+config.loggers.console.bedrock = {};
+// move 'module' meta to a pretty message prefix if available
+config.loggers.console.bedrock.modulePrefix = true;
 
 // file transport for app logging
 config.loggers.app = {};
@@ -93,6 +97,8 @@ config.loggers.app.maxFiles = 10;
 config.loggers.app.bedrock = {};
 // chown the logging dir to bedrock.config.core.running.userId
 config.loggers.app.bedrock.enableChownDir = false;
+// move 'module' meta to a pretty message prefix if available
+config.loggers.app.bedrock.modulePrefix = false;
 
 // file transport for access logging
 config.loggers.access = {};
@@ -109,6 +115,8 @@ config.loggers.access.maxFiles = 10;
 config.loggers.access.bedrock = {};
 // chown the logging dir to bedrock.config.core.running.userId
 config.loggers.access.bedrock.enableChownDir = false;
+// move 'module' meta to a pretty message prefix if available
+config.loggers.access.bedrock.modulePrefix = false;
 
 // file transport for error logging
 config.loggers.error = {};
@@ -125,6 +133,8 @@ config.loggers.error.maxFiles = 10;
 config.loggers.error.bedrock = {};
 // chown the logging dir to bedrock.config.core.running.userId
 config.loggers.error.bedrock.enableChownDir = false;
+// move 'module' meta to a pretty message prefix if available
+config.loggers.error.bedrock.modulePrefix = false;
 
 // transport for email logging
 config.loggers.email = {};

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -62,6 +62,20 @@ container.get = container.add = function(id) {
   if(!existing) {
     var wrapper = {};
     wrapper.__proto__ = logger;
+    wrapper.child = function(childMeta) {
+      var child = {};
+      child.__proto__ = wrapper;
+      child.log = function(level, msg, meta) {
+        meta = Object.assign({}, childMeta, meta);
+        if(meta.module) {
+          msg = '[' + childMeta.module + '] ' + msg;
+          delete meta.module;
+        }
+        return child.__proto__.log.apply(logger, [level, msg, meta]);
+      };
+      child.setLevels(levels);
+      return child;
+    };
     logger = container.loggers[id] = wrapper;
   }
   return logger;

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -57,22 +57,24 @@ var container = new winston.Container();
 container._get = container.get;
 container._add = container.add;
 container.get = container.add = function(id) {
-  var existing = container.loggers[id];
-  var logger = container._get.apply(container, arguments);
+  const existing = container.loggers[id];
+  let logger = container._get.apply(container, arguments);
   if(!existing) {
-    var wrapper = {};
-    wrapper.__proto__ = logger;
+    const wrapper = Object.create(logger);
+    wrapper.log = function(level, msg, meta) {
+      // merge per-logger and per-log meta and call parent logger
+      meta = Object.assign({}, this.meta, meta);
+      return Object.getPrototypeOf(wrapper).log.apply(
+        wrapper, [level, msg, meta]);
+    };
     wrapper.child = function(childMeta) {
-      var child = {};
-      child.__proto__ = wrapper;
-      child.log = function(level, msg, meta) {
-        meta = Object.assign({}, childMeta, meta);
-        if(meta.module) {
-          msg = '[' + childMeta.module + '] ' + msg;
-          delete meta.module;
-        }
-        return child.__proto__.log.apply(logger, [level, msg, meta]);
-      };
+      // simple string name is shortcut for {module: name}
+      if(typeof childMeta === 'string') {
+        childMeta = {module: childMeta};
+      }
+      // create child logger with merged meta data from parent
+      const child = Object.create(this);
+      child.meta = Object.assign({}, this.meta, childMeta);
       child.setLevels(levels);
       return child;
     };
@@ -121,6 +123,44 @@ function chown(filename, callback) {
   callback();
 }
 
+// class to handle pretty printing module name
+class ModuleConsoleTransport extends winston.transports.Console {
+  constructor(config) {
+    super(config);
+    this.modulePrefix = config.bedrock.modulePrefix;
+  }
+  log(level, msg, meta, callback) {
+    if(this.modulePrefix && 'module' in meta) {
+      // add pretty module prefix
+      msg = '[' + meta.module + '] ' + msg;
+      // copy to avoid changing shared original
+      meta = Object.assign({}, meta);
+      // remove module so not re-printed as details
+      delete meta.module;
+    }
+    super.log(level, msg, meta, callback);
+  }
+}
+
+// class to handle pretty printing module name
+class ModuleFileTransport extends winston.transports.File {
+  constructor(config) {
+    super(config);
+    this.modulePrefix = config.bedrock.modulePrefix;
+  }
+  log(level, msg, meta, callback) {
+    if(this.modulePrefix && 'module' in meta) {
+      // add pretty module prefix
+      msg = '[' + meta.module + '] ' + msg;
+      // copy to avoid changing shared original
+      meta = Object.assign({}, meta);
+      // remove module so not re-printed as details
+      delete meta.module;
+    }
+    super.log(level, msg, meta, callback);
+  }
+}
+
 /**
  * Initializes the logging system.
  *
@@ -130,10 +170,10 @@ container.init = function(callback) {
   if(cluster.isMaster) {
     // create shared transports
     var transports = container.transports;
-    transports.console = new winston.transports.Console(config.loggers.console);
-    transports.app = new winston.transports.File(config.loggers.app);
-    transports.access = new winston.transports.File(config.loggers.access);
-    transports.error = new winston.transports.File(config.loggers.error);
+    transports.console = new ModuleConsoleTransport(config.loggers.console);
+    transports.app = new ModuleFileTransport(config.loggers.app);
+    transports.access = new ModuleFileTransport(config.loggers.access);
+    transports.error = new ModuleFileTransport(config.loggers.error);
     transports.email = new WinstonMail(config.loggers.email);
 
     // set unique names for file transports
@@ -232,23 +272,31 @@ container.init = function(callback) {
 
     // pull out any meta values that are pre-formatted
     meta = meta || {};
-    var preformatted = null;
-    if(brUtil.isObject(meta)) {
-      preformatted = meta.preformatted;
-      delete meta.preformatted;
+    let preformatted = null;
+    let metaIsObject = brUtil.isObject(meta);
+    let module = null;
+    if(metaIsObject) {
+      if('preformatted' in meta) {
+        preformatted = meta.preformatted;
+        delete meta.preformatted;
+      }
+      if('module' in meta) {
+        module = meta.module;
+        delete meta.module;
+      }
     }
     // stringify and include the worker PID in the meta information
-    var json;
+    let json;
     try {
       json = JSON.stringify(meta, null, 2);
     } catch(e) {
-      json = JSON.stringify(cycle.decycle, null, 2);
+      json = JSON.stringify(cycle.decycle(meta), null, 2);
     }
-    var error;
+    let error;
     if(meta instanceof Error) {
       error = ('stack' in meta) ? meta.stack : meta;
       meta = {error: error, workerPid: process.pid};
-    } else if(brUtil.isObject(meta) && 'error' in meta) {
+    } else if(metaIsObject && 'error' in meta) {
       error = ('stack' in meta.error) ? meta.error.stack : meta.error;
       meta = {error: error, workerPid: process.pid};
     } else {
@@ -263,6 +311,11 @@ container.init = function(callback) {
     // only add pre-formatted entries if they exist
     if(preformatted) {
       meta.preformatted = preformatted;
+    }
+
+    // only add module if it was specified
+    if(module) {
+      meta.module = module;
     }
 
     // send logger message to master


### PR DESCRIPTION
- Add `.child(meta)` method to loggers that has common metadata.
- The special `module` key is used to prefix messages with `[module]`
  and then removed from the metadata. These adjustments may be removed in
  the future but are necessary with the current lower level logging
  mechanisms.

This is used like:

``` js
var logger = bedrock.loggers.get('app').child({module: 'bedrock-foobar'});
logger.info('ima log');
```

and results in:

```
2016-10-05T18:24:53.927Z - info: [bedrock-foobar] ima log workerPid=9611
```

I'm not so thrilled about how this patch works.  It adjusts the msg text and removes the module meta if present. That makes it harder to use logging handlers that want all the raw semantic data. I'm not sure if there's an easy way to get console and file loggers alone to do this manipulation. The module metadata removal is to avoid it being printed out for every log. It may be ok to just use this for now until a better solution comes about. It's not too terrible that the module data is in the message but could potentially stop some automatic module queries. Thoughts?
