### PR TITLE
Add pushComputed support.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,3 +1,4 @@
 {
-  "node": true
+  "node": true,
+  "esversion": 6
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # bedrock ChangeLog
 
 ### Added
-- Add new `bedrock.util.Config` API. See README for details.
+- Add `bedrock.util.config` utilities:
+  - Add `bedrock.util.config.Config` OO wrapper API.
+  - Common `bedrock.util.config.main` Config wrapper for `bedrock.config`.
+  - See README for usage details.
 
 ## 1.2.5 - 2016-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 - Updated dependencies.
+- Updated to node >= 6.
 
 ## 1.2.5 - 2016-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   - Common `bedrock.util.config.main` Config wrapper for `bedrock.config`.
   - See README for usage details.
 
+### Changed
+- Updated dependencies.
+
 ## 1.2.5 - 2016-07-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - Add `bedrock.util.config.Config` OO wrapper API.
   - Common `bedrock.util.config.main` Config wrapper for `bedrock.config`.
   - See README for usage details.
+- ci-test target with tap mocha reporter.
 
 ### Changed
 - Updated dependencies.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,9 +41,12 @@ module.exports = function(grunt) {
   grunt.config('jshint', {
     all: {
       options: grunt.config('ci') ? {
+        jshintrc: true,
         reporter: 'checkstyle',
         reporterOutput: 'reports/jshint.xml'
-      } : {},
+      } : {
+        jshintrc: true
+      },
       src: grunt.config('js')
     }
   });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
     _jscsOptions.reporterOutput = 'reports/jscs.xml';
   }
 
-  grunt.loadNpmTasks("grunt-jscs");
+  grunt.loadNpmTasks('grunt-jscs');
   grunt.config('jscs', {
     all: {
       options: _jscsOptions,

--- a/README.md
+++ b/README.md
@@ -362,9 +362,9 @@ simplify dependency issues by allowing values to be computed at runtime from a
 function or string template. (Note there is a small cost with computed config
 values which could be important depending on the use case.)
 
-`bedrock.util.Config` creates a wrapper around a config object and optional
-options. This wrapper exposes a new, helpful API that is detailed below. A
-common setup could look like the following.
+`bedrock.util.config.Config` creates a wrapper around a config object and
+optional options. This wrapper exposes a new, helpful API that is detailed
+below. A common setup could look like the following.
 
 ```js
 // an empty config object
@@ -377,16 +377,16 @@ let options = {
   locals: config
 };
 // wrap the config
-let c = new bedrock.util.Config(config, options);
+let c = new bedrock.util.config.Config(config, options);
 ```
 
 Bedrock provides a shared wrapper around the common `bedrock.config` as
-`bedrock.util.config`.
+`bedrock.util.config.main`.
 
 To do simple sets of config data, use the `set()` API.
 
 ```js
-let c = bedrock.util.config;
+let c = bedrock.util.config.main;
 // set a config variable with a path
 // path components are created as needed
 c.set('server.port', 8443);
@@ -399,7 +399,7 @@ data. Objects in the path are created as needed.
 
 ```js
 let config = bedrock.config;
-let c = bedrock.util.config;
+let c = bedrock.util.config.main;
 // create container object if needed
 c.setDefault('accounts.admin', {});
 // the config is just a normal object
@@ -417,7 +417,7 @@ powerful feature where values will be calculated at runtime.
 ```js
 let config = bedrock.config;
 // get the Config wrapper for the default bedrock.config
-let c = bedrock.util.config;
+let c = bedrock.util.config.main;
 // set static values
 c.set('server.port', 8443);
 c.set('server.domain', 'bedrock.dev');
@@ -433,7 +433,7 @@ are updated the computed values will reflect the change.
 
 ```js
 let config = bedrock.config;
-let c = bedrock.util.config;
+let c = bedrock.util.config.main;
 c.set('server.port', 8443);
 c.set('server.domain', 'bedrock.dev');
 c.setComputed('server.host', () => {
@@ -452,7 +452,7 @@ console.log(config.server.host); // "bedrock.dev"
 `bind()` functionality. A helper called `computer()` will do this for you.
 ```js
 let config = bedrock.config;
-let cc = bedrock.util.config.computer();
+let cc = bedrock.util.config.main.computer();
 cc('server.host', () => {
   // only add the port if it's not the well known default
   if(config.server.port !== 443) {
@@ -467,7 +467,7 @@ templates)[https://lodash.com/docs/#template].
 
 ```js
 let config = bedrock.config;
-let cc = bedrock.util.config.computer();
+let cc = bedrock.util.config.main.computer();
 cc('server.baseUri', 'https://${server.host}');
 console.log(config.server.baseUri); // "https://bedrock.dev:8443"
 // use locals option to simplify templates
@@ -478,7 +478,7 @@ cc('base.computed', '${a}:${b}:${c}', {locals: config.base});
 Setting or computing multiple values with one call uses an object notation:
 
 ```js
-let c = bedrock.util.config;
+let c = bedrock.util.config.main;
 let cc = c.computer();
 c.set({
   'server.port': 8443,
@@ -499,7 +499,7 @@ parent array if needed.
 
 ```js
 let config = bedrock.config;
-let c = bedrock.util.config;
+let c = bedrock.util.config.main;
 let cc = c.computer();
 cc('server.baseUri', 'https://${server.host}');
 c.setDefault('resources', []);

--- a/README.md
+++ b/README.md
@@ -492,6 +492,21 @@ cc({
 });
 ```
 
+Computed values can be added to an array using indexing or the `pushComputed`
+feature. If indexing is used the array must already exist or the
+`{parentDefault: []}` option should be used. `pushComputed` will create the
+parent array if needed.
+
+```js
+let config = bedrock.config;
+let c = bedrock.util.config;
+let cc = c.computer();
+cc('server.baseUri', 'https://${server.host}');
+c.setDefault('resources', []);
+cc('resources[0]', '${server.baseUri}/r/0');
+c.pushComputed('resources', '${server.baseUri}/r/1');
+```
+
 ### bedrock.events
 
 It's sometimes necessary to allow modules to coordinate with each other in

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -242,20 +242,20 @@ function _configureLoggers() {
       var transports = cat.split('=')[1].split(';');
       transports.forEach(function(transport) {
         if(transport.indexOf('-') === 0) {
-          var tName = transport.slice(1);
-          var tIndex = catTransports.indexOf(tName);
+          const tName = transport.slice(1);
+          const tIndex = catTransports.indexOf(tName);
           if(tIndex !== -1) {
             catTransports.splice(tIndex, 1);
           }
         } else if(transport.indexOf('+') === 0) {
-          var tName = transport.slice(1);
-          var tIndex = catTransports.indexOf(tName);
+          const tName = transport.slice(1);
+          const tIndex = catTransports.indexOf(tName);
           if(tIndex === -1) {
             catTransports.push(tName);
           }
         } else {
-          var tName = transport;
-          var tIndex = catTransports.indexOf(tName);
+          const tName = transport;
+          const tIndex = catTransports.indexOf(tName);
           if(tIndex === -1) {
             catTransports.push(tName);
           }

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -70,6 +70,34 @@ if(cluster.isMaster) {
   };
 }
 
+function chown(filename, callback) {
+  if(config.core.running.userId) {
+    var uid = config.core.running.userId;
+    if(typeof uid !== 'number') {
+      var user = null;
+      if(posix) {
+        user = posix.getpwnam(uid);
+      } else if(process.platform === 'win32') {
+        // on Windows, just get the current UID
+        user = {uid: process.getuid()};
+      }
+      if(!user && !posix && typeof uid !== 'number') {
+        return callback(new Error(
+          '"posix" package not available to convert user "' + uid + '" ' +
+          'to a number. Try using a uid number instead.'));
+      }
+      if(!user) {
+        return callback(new Error('No system user id for "' + uid + '".'));
+      }
+      uid = user.uid;
+    }
+    if(process.getgid) {
+      return fs.chown(filename, uid, process.getgid(), callback);
+    }
+  }
+  callback();
+}
+
 /**
  * Initializes the logging system.
  *
@@ -89,35 +117,6 @@ container.init = function(callback) {
     transports.app.name = 'app';
     transports.access.name = 'access';
     transports.error.name = 'error';
-
-    function chown(filename, callback) {
-      if(config.core.running.userId) {
-        var uid = config.core.running.userId;
-        if(typeof uid !== 'number') {
-          var user = null;
-          if(posix) {
-            user = posix.getpwnam(uid);
-          } else if(process.platform === 'win32') {
-            // on Windows, just get the current UID
-            user = {uid: process.getuid()};
-          }
-          if(!user && !posix && typeof uid !== 'number') {
-            return callback(new Error(
-              '"posix" package not available to convert user "' + uid + '" ' +
-              'to a number. Try using a uid number instead.'));
-          }
-          if(!user) {
-            return callback(new Error(
-              'No system user id for "' + uid + '".'));
-          }
-          uid = user.uid;
-        }
-        if(process.getgid) {
-          return fs.chown(filename, uid, process.getgid(), callback);
-        }
-      }
-      callback();
-    }
 
     async.waterfall([
       function(callback) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -390,7 +390,7 @@ api.config.Config.prototype.setComputed =
  * Create a bound setComputed function for this Config instance. Used to
  * simplify code.
  *
- * let cc = bedrock.util.config.computer();
+ * let cc = bedrock.util.config.main.computer();
  * cc('...', ...);
  *
  * @return bound setComputed function.
@@ -454,18 +454,18 @@ api.boolify = function(value) {
   }
   if(typeof value === 'string' && value) {
     switch(value.toLowerCase()) {
-    case 'true':
-    case 't':
-    case '1':
-    case 'yes':
-    case 'y':
-      return true;
-    case 'false':
-    case 'f':
-    case '0':
-    case 'no':
-    case 'n':
-      return false;
+      case 'true':
+      case 't':
+      case '1':
+      case 'yes':
+      case 'y':
+        return true;
+      case 'false':
+      case 'f':
+      case '0':
+      case 'no':
+      case 'n':
+        return false;
     }
   }
   // if here we couldn't parse it

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -238,6 +238,9 @@ api.clone = function(value) {
 
 // config utilities
 
+// config namespace
+api.config = {};
+
 // check if argument looks like a string or array path
 function _isPath(maybePath) {
   return typeof maybePath === 'string' || Array.isArray(maybePath);
@@ -269,7 +272,7 @@ function _setDefault(object, path, value) {
  *          locals: object containing variables used for string templates.
  *                  Defaults to main config object.
  */
-api.Config = function(object, options) {
+api.config.Config = function(object, options) {
   this.object = object;
   this.options = options || {};
 };
@@ -284,7 +287,7 @@ api.Config = function(object, options) {
  *          key and value pairs.
  * @param value value to set at the path when using single path.
  */
-api.Config.prototype.set = function(path, value) {
+api.config.Config.prototype.set = function(path, value) {
   if(!_isPath(path)) {
     Object.keys(path).forEach(key => _.set(this.object, key, path[key]));
     return;
@@ -308,7 +311,7 @@ api.Config.prototype.set = function(path, value) {
  * @return the last element of the path or a path indexed object with element
  *           values.
  */
-api.Config.prototype.setDefault = function(path, value) {
+api.config.Config.prototype.setDefault = function(path, value) {
   if(!_isPath(path)) {
     var paths = {};
     Object.keys(path).forEach((key) => {
@@ -336,7 +339,8 @@ api.Config.prototype.setDefault = function(path, value) {
  *          locals: object containing variables used for string templates.
  *          parentDefault: value for parent if it does not exist.
  */
-api.Config.prototype.setComputed = function(path, fnOrExpression, options) {
+api.config.Config.prototype.setComputed =
+  function(path, fnOrExpression, options) {
   if(!_isPath(path)) {
     options = fnOrExpression;
     Object.keys(path).forEach(key => this.setComputed(key, path[key], options));
@@ -391,7 +395,7 @@ api.Config.prototype.setComputed = function(path, fnOrExpression, options) {
  *
  * @return bound setComputed function.
  */
-api.Config.prototype.computer = function() {
+api.config.Config.prototype.computer = function() {
   return this.setComputed.bind(this);
 };
 
@@ -405,7 +409,8 @@ api.Config.prototype.computer = function() {
  * @param [options] options to use:
  *          locals: object containing variables used for string templates.
  */
-api.Config.prototype.pushComputed = function(path, fnOrExpression, options) {
+api.config.Config.prototype.pushComputed =
+  function(path, fnOrExpression, options) {
   // get target or default array
   let target = _.get(this.object, path, []);
   // add next index
@@ -420,7 +425,7 @@ api.Config.prototype.pushComputed = function(path, fnOrExpression, options) {
 /**
  * Shared wrapper for the standard bedrock config.
  */
-api.config = new api.Config(config);
+api.config.main = new api.config.Config(config);
 
 /**
  * Generates a new v4 UUID.

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -251,7 +251,7 @@ function _setDefault(object, path, value) {
   if(path.length) {
     let target = _.get(object, path);
     if(!target) {
-      target = value || {};
+      target = value;
       _.set(object, path, target);
     }
     return target;
@@ -334,6 +334,7 @@ api.Config.prototype.setDefault = function(path, value) {
  *          path value.
  * @param [options] options to use:
  *          locals: object containing variables used for string templates.
+ *          parentDefault: value for parent if it does not exist.
  */
 api.Config.prototype.setComputed = function(path, fnOrExpression, options) {
   if(!_isPath(path)) {
@@ -360,7 +361,8 @@ api.Config.prototype.setComputed = function(path, fnOrExpression, options) {
   // get key
   var targetKey = path.slice(-1);
   // get or create target parent object
-  var target = _setDefault(this.object, targetPath);
+  var parentDefault = options.parentDefault || {};
+  var target = _setDefault(this.object, targetPath, parentDefault);
   // setup property
   var _isSet = false;
   var _value;
@@ -391,6 +393,28 @@ api.Config.prototype.setComputed = function(path, fnOrExpression, options) {
  */
 api.Config.prototype.computer = function() {
   return this.setComputed.bind(this);
+};
+
+/**
+ * Push a getter to an array specified by a config path. See setComputed for an
+ * explaination of how getters work.
+ *
+ * @param path lodash-style string or array path.
+ * @param fnOrExpression a lodash template or a function used to compute the
+ *          path value.
+ * @param [options] options to use:
+ *          locals: object containing variables used for string templates.
+ */
+api.Config.prototype.pushComputed = function(path, fnOrExpression, options) {
+  // get target or default array
+  let target = _.get(this.object, path, []);
+  // add next index
+  let pushPath = _.toPath(path);
+  pushPath.push(target.length);
+  // use default parent array
+  let pushOptions = Object.assign({}, options, {parentDefault: []});
+  // set computed array element
+  this.setComputed(pushPath, fnOrExpression, pushOptions);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "posix": "^4.0.0"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-cli": "~0.1.13",
-    "grunt-contrib-jshint": "~0.11.1",
-    "grunt-jscs": "^2.1.0"
+    "grunt": "~1.0.1",
+    "grunt-cli": "~1.2.0",
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-jscs": "~3.0.1"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt-jscs": "~3.0.1"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=6"
   },
   "directories": {
     "lib": "./lib/bedrock"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "node index.js",
     "test": "node index.js test",
+    "ci-test": "node index.js test --mocha-reporter=tap",
     "lint": "grunt jshint",
     "ci-lint": "grunt --no-color jshint --mode=ci || exit 0",
     "coverage": "rm -rf coverage && ./node_modules/.bin/istanbul cover index.js -- test --mocha-reporter tap && ./node_modules/.bin/istanbul report --root coverage lcov cobertura"

--- a/tests/test.js
+++ b/tests/test.js
@@ -450,14 +450,14 @@ describe('bedrock', function() {
       });
     });
 
-    describe('examples', function() {
-      it('should support README examples (set)', function() {
+    describe('README examples', function() {
+      it('should support set', function() {
         c.set('server.port', 8443);
 
         config.server.port.should.equal(8443);
       });
 
-      it('should support README examples (setDefault)', function() {
+      it('should support setDefault', function() {
         c.setDefault('accounts.admin', {});
         config.accounts.admin.name = 'Ima Admin';
         c.set('accounts.admin.id', 1);
@@ -471,7 +471,7 @@ describe('bedrock', function() {
         config.accounts.account123.name.should.equal('Account 123');
       });
 
-      it('should support README examples (setComputed)', function() {
+      it('should support setComputed', function() {
         c.set('server.port', 8443);
         c.set('server.domain', 'bedrock.dev');
         c.setComputed('server.host', () => {
@@ -483,7 +483,7 @@ describe('bedrock', function() {
         config.server.host.should.equal('bedrock.dev:8443');
       });
 
-      it('should support README examples (setComputed2)', function() {
+      it('should support setComputed2', function() {
         c.set('server.port', 8443);
         c.set('server.domain', 'bedrock.dev');
         c.setComputed('server.host', () => {
@@ -502,7 +502,7 @@ describe('bedrock', function() {
         config.server.host.should.equal('bedrock.dev');
       });
 
-      it('should support README examples (computer)', function() {
+      it('should support computer', function() {
         c.set('server.port', 8443);
         c.set('server.domain', 'bedrock.dev');
         cc('server.host', () => {
@@ -522,7 +522,7 @@ describe('bedrock', function() {
         config.server.host.should.equal('bedrock.dev');
       });
 
-      it('should support README examples (templates)', function() {
+      it('should support templates', function() {
         c.set('server.port', 8443);
         c.set('server.domain', 'bedrock.dev');
         cc('server.host', () => {
@@ -552,7 +552,7 @@ describe('bedrock', function() {
         config.base.computed2.should.equal('a:b:c');
       });
 
-      it('should support README examples (multi)', function() {
+      it('should support multi', function() {
         c.set({
           'server.port': 8443,
           'server.domain': 'bedrock.dev',
@@ -572,7 +572,7 @@ describe('bedrock', function() {
         config.users.admin.url.should.equal('https://bedrock.dev:8443/users/1');
       });
 
-      it('should support README examples (arrays)', function() {
+      it('should support arrays', function() {
         c.set('server.port', 8443);
         c.set('server.domain', 'bedrock.dev');
         cc('server.host', () => {
@@ -591,7 +591,9 @@ describe('bedrock', function() {
         config.resources[0].should.equal('https://bedrock.dev:8443/r/0');
         config.resources[1].should.equal('https://bedrock.dev:8443/r/1');
       });
+    });
 
+    describe('examples', function() {
       it('should support an example', function() {
         let config = {};
         let options = {config: config, locals: config};

--- a/tests/test.js
+++ b/tests/test.js
@@ -61,7 +61,7 @@ describe('bedrock', function() {
     });
   });
 
-  describe('util.Config', function() {
+  describe('util.config', function() {
     // simplify most tests with common config setup
     let config;
     let c;
@@ -75,7 +75,7 @@ describe('bedrock', function() {
         // set locals to our custom config root
         locals: config
       };
-      c = new bedrock.util.Config(config, options);
+      c = new bedrock.util.config.Config(config, options);
       cc = c.computer();
     });
 
@@ -276,7 +276,7 @@ describe('bedrock', function() {
 
     describe('default config', function() {
       // computed config for main config
-      let _cc = bedrock.util.config.computer();
+      let _cc = bedrock.util.config.main.computer();
 
       // config testing namespace
       const ns = '_mocha';
@@ -301,7 +301,7 @@ describe('bedrock', function() {
     describe('templates', function() {
       it('should create', function() {
         let _options = {locals: config};
-        let _cc = new bedrock.util.Config(config, _options).computer();
+        let _cc = new bedrock.util.config.Config(config, _options).computer();
         config.base.a = 'a';
         config.base.b = 'b';
         _cc('computed', '${base.a + base.b}', _options);
@@ -309,7 +309,7 @@ describe('bedrock', function() {
       });
       it('should create with custom locals', function() {
         let _options = {locals: config.base};
-        let _cc = new bedrock.util.Config(config, _options).computer();
+        let _cc = new bedrock.util.config.Config(config, _options).computer();
         config.base.a = 'a';
         config.base.b = 'b';
         _cc('computed', '${a + b}');
@@ -317,7 +317,7 @@ describe('bedrock', function() {
       });
       it('should create with per-call locals', function() {
         let _options = {locals: config.base};
-        let _cc = new bedrock.util.Config(config).computer();
+        let _cc = new bedrock.util.config.Config(config).computer();
         config.base.a = 'a';
         config.base.b = 'b';
         _cc('computed', '${a + b}', _options);
@@ -325,7 +325,7 @@ describe('bedrock', function() {
       });
       it('should update', function() {
         let _options = {locals: config};
-        let _cc = new bedrock.util.Config(config, _options).computer();
+        let _cc = new bedrock.util.config.Config(config, _options).computer();
         config.base.a = 'a';
         config.base.b = 'b';
         _cc('computed', '${base.a + base.b}');
@@ -597,7 +597,7 @@ describe('bedrock', function() {
       it('should support an example', function() {
         let config = {};
         let options = {config: config, locals: config};
-        let c = new bedrock.util.Config(config, options);
+        let c = new bedrock.util.config.Config(config, options);
         let cc = c.computer();
         c.set('server.port', 8443);
         // direct access, 'server' container known to exist

--- a/tests/test.js
+++ b/tests/test.js
@@ -278,15 +278,13 @@ describe('bedrock', function() {
       // computed config for main config
       let _cc = bedrock.util.config.main.computer();
 
-      // config testing namespace
-      const ns = '_mocha';
       // ensure empty config container
       beforeEach('create config', function() {
-        bedrock.config[ns] = {};
+        bedrock.config._mocha = {};
       });
       // clean up test config
       afterEach('remove config', function() {
-        delete bedrock.config[ns];
+        delete bedrock.config._mocha;
       });
 
       it('should use default config', function() {


### PR DESCRIPTION
- Add parentDefault option. Needed to allow a missing parent to be created as an array.
- Add pushComputed method.
- Add tests and docs.