### PR TITLE
Remove config.paths defaults.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # bedrock ChangeLog
 
+### Changed
+- Deprecated default values for `config.paths`. A warning will be printed.  A
+  future major version will force values to be set by applications.
+
 ## 1.4.0 - 2016-12-09
 
 ### Added

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -3,8 +3,9 @@
  */
 var async = require('async');
 var brUtil = require('./util');
-var config = require('./config');
+var cc = brUtil.config.main.computer();
 var cluster = require('cluster');
+var config = require('./config');
 var events = require('./events');
 var jsonld = require('./jsonld');
 var loggers = require('./loggers');
@@ -12,6 +13,7 @@ var path = require('path');
 var pkginfo = require('pkginfo');
 var program = require('commander');
 var test = require('./test');
+const BedrockError = brUtil.BedrockError;
 
 // core API
 var api = {};
@@ -26,6 +28,43 @@ module.exports = api;
 
 // read package.json fields
 pkginfo(module, 'version');
+
+// config paths
+// configured here instead of config.js due to util dependency issues
+// FIXME: v2.0.0: remove when removing warnings below.
+const _warningShown = {
+  cache: false,
+  log: false
+};
+cc({
+  'paths.cache': () => {
+    // FIXME: v2.0.0: remove warning and default and throw exception .
+    //throw new BedrockError(
+    //  'bedrock.config.paths.cache not set.',
+    //  'ConfigError');
+    const cachePath = path.join(__dirname, '..', '.cache');
+    if(!_warningShown.cache) {
+      loggers.get('app').error(
+        `"bedrock.config.paths.cache" not set, using default: "${cachePath}"`);
+      _warningShown.cache = true;
+    }
+    return cachePath;
+  },
+  'paths.log': () => {
+    // FIXME: v2.0.0: remove warning and default and throw exception .
+    //throw new BedrockError(
+    //  'bedrock.config.paths.log not set.',
+    //  'ConfigError');
+    const logPath = path.join('/tmp/bedrock-dev');
+    if(!_warningShown.log) {
+      // Using console since this config value used during logger setup.
+      console.warn('WARNING: ' +
+        `"bedrock.config.paths.log" not set, using default: "${logPath}"`);
+      _warningShown.log = true;
+    }
+    return logPath;
+  }
+});
 
 // expose bedrock program
 api.program = program.version(api.version);

--- a/lib/config.js
+++ b/lib/config.js
@@ -49,8 +49,10 @@ config.constants = {};
 
 // common paths
 config.paths = {
-  cache: path.join(__dirname, '..', 'cache'),
-  log: '/tmp/bedrock-dev'
+  // note: defaults configured in bedrock.js to fail.
+  // applications MUST set these if used
+  cache: null,
+  log: null
 };
 
 /**


### PR DESCRIPTION
It is difficult to have defaults that make sense in all cases. Using
computed configs we can require the values to be set by high level
applications if they are used.