### PR TITLE
Add `noError` helper.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -1,13 +1,13 @@
 /*
  * Copyright (c) 2012-2017 Digital Bazaar, Inc. All rights reserved.
  */
-var config = require('./config');
-var events = require('./events');
-var path = require('path');
+const config = require('./config');
+const events = require('./events');
+const path = require('path');
 const BedrockError = require('./util').BedrockError;
 
 // module API
-var api = {};
+const api = {};
 module.exports = api;
 
 // add mocha as available test framework
@@ -27,10 +27,10 @@ config.mocha.tests = [];
 config.mocha.tests.push(path.join(__dirname, '..', 'tests'));
 
 events.on('bedrock-cli.init', function(callback) {
-  var bedrock = require('./bedrock');
+  const bedrock = require('./bedrock');
 
   // add test command
-  var command = bedrock.program
+  const command = bedrock.program
     .command('test')
     .description('run tests')
     .option(
@@ -48,7 +48,7 @@ events.on('bedrock-cli.init', function(callback) {
 });
 
 events.on('bedrock-cli.ready', function(callback) {
-  var command = config.cli.command;
+  const command = config.cli.command;
   if(command.name() !== 'test') {
     return callback();
   }
@@ -63,9 +63,9 @@ events.on('bedrock-cli.ready', function(callback) {
 
 events.on('bedrock.started', function() {
   if(config.cli.command.name() === 'test') {
-    var bedrock = require('./bedrock');
-    var logger = bedrock.loggers.get('app');
-    var state = {pass: true};
+    const bedrock = require('./bedrock');
+    const logger = bedrock.loggers.get('app');
+    const state = {pass: true};
     bedrock.runOnce('bedrock.test', function(callback) {
       console.log('Running Test Frameworks...\n');
       logger.info('running test frameworks...');
@@ -119,7 +119,7 @@ events.on('bedrock.tests.run', function(state, callback) {
  * @param test the global test state.
  */
 api.shouldRunFramework = function(framework) {
-  var frameworks = config.cli.command.framework;
+  const frameworks = config.cli.command.framework;
   // default to run, else check for name in frameworks list
   return !frameworks || frameworks.split(/[ ,]+/).indexOf(framework) !== -1;
 };
@@ -130,13 +130,13 @@ api.shouldRunFramework = function(framework) {
  * @param test the global test state.
  */
 function runMocha(state, callback) {
-  var bedrock = require('./bedrock');
-  var Mocha = require('mocha');
-  var chai = require('chai');
-  var chaiAsPromised = require('chai-as-promised');
-  var fs = require('fs');
+  const bedrock = require('./bedrock');
+  const Mocha = require('mocha');
+  const chai = require('chai');
+  const chaiAsPromised = require('chai-as-promised');
+  const fs = require('fs');
 
-  var logger = bedrock.loggers.get('app');
+  const logger = bedrock.loggers.get('app');
 
   // setup chai / chai-as-promised
   chai.use(chaiAsPromised);
@@ -147,14 +147,14 @@ function runMocha(state, callback) {
 
   global.assertNoError = (err) => {
     if(err) {
-      var obj = err instanceof BedrockError ? err.toObject() : err;
+      const obj = err instanceof BedrockError ? err.toObject() : err;
       console.error(
         'An unexpected error occurred:', JSON.stringify(obj, null, 2));
       throw err;
     }
   };
 
-  var mocha = new Mocha(config.mocha.options);
+  const mocha = new Mocha(config.mocha.options);
 
   // add test files
   if(config.cli.command.mochaTest) {
@@ -182,7 +182,7 @@ function runMocha(state, callback) {
   // add a file or directory
   function _add(_path) {
     if(fs.existsSync(_path)) {
-      var stats = fs.statSync(_path);
+      const stats = fs.statSync(_path);
       if(stats.isDirectory()) {
         fs.readdirSync(_path).sort().forEach(function(file) {
           if(path.extname(file) === '.js') {

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2012-2015 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2012-2017 Digital Bazaar, Inc. All rights reserved.
  */
 var config = require('./config');
 var events = require('./events');
 var path = require('path');
+const BedrockError = require('./util').BedrockError;
 
 // module API
 var api = {};
@@ -143,6 +144,15 @@ function runMocha(state, callback) {
   // set globals for tests to use
   global.chai = chai;
   global.should = chai.should();
+
+  global.assertNoError = (err) => {
+    if(err) {
+      var obj = err instanceof BedrockError ? err.toObject() : err;
+      console.error(
+        'An unexpected error occurred:', JSON.stringify(obj, null, 2));
+      throw err;
+    }
+  };
 
   var mocha = new Mocha(config.mocha.options);
 


### PR DESCRIPTION
My experiments show that calling `done(err)` does not produce any result different from `throw err`.  Also, afaik the only way to get the entire error details is to JSON.stringify it as in the PR.  This is modeled after the manual process I've been using.