### PR TITLE
Add bedrock-cli.parsed event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # bedrock ChangeLog
 
+## 1.13.0 - TBD
+
+## Added
+- Add `bedrock-cli.parsed` event.
+
+### Changed
+- Update copyright notices.
+- Style fixes.
+
 ## 1.12.1 - 2018-05-10
 
 ### Changed

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,8 @@
-/*
- * Bedrock Gruntfile.
- *
- * Copyright (c) 2013-2015 Digital Bazaar, Inc. All rights reserved.
+/*!
+ * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
+'use strict';
+
 module.exports = function(grunt) {
   'use strict';
 

--- a/README.md
+++ b/README.md
@@ -597,6 +597,11 @@ event or causes the application to exit early.
 
 - **bedrock-cli.init**
   - Emitted before command line parsing. Allows registration of new subcommands.
+- **bedrock-cli.parsed**
+  - Emitted after command line parsing. Allows for configuration of loggers
+    based on command line flags. For instance, a logger may provide for the
+    specification of a `logGroupName` that may be computed at runtime based
+    on some command line flag(s).
 - **bedrock-loggers.init**
   - Emitted after command line parsing. Allows registration of new logging
     transports prior to initialization of the logging subsystem.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://digitalbazaar.com/wp-content/uploads/BedrockLogo.png">
 
-[![Build Status](http://ci.digitalbazaar.com/buildStatus/icon?job=bedrock)](http://ci.digitalbazaar.com/job/bedrock)
+[![Build Status](https://ci.digitalbazaar.com/buildStatus/icon?job=bedrock)](https://ci.digitalbazaar.com/job/bedrock)
 [![Dependency Status](https://img.shields.io/david/digitalbazaar/bedrock.svg)](https://david-dm.org/digitalbazaar/bedrock)
 
 A core foundation for rich Web applications.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2012-2015 Digital Bazaar, Inc. All rights reserved.
  */
-var bedrock = require('./lib/bedrock');
+const bedrock = require('./lib/bedrock');
 
 // run with development defaults
 bedrock.start();

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
-/*
- * Copyright (c) 2012-2015 Digital Bazaar, Inc. All rights reserved.
+/*!
+ * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
+'use strict';
+
 const bedrock = require('./lib/bedrock');
 
 // run with development defaults

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -122,8 +122,11 @@ api.start = function(options, done) {
     beforeInit: function(callback) {
       events.emit('bedrock-cli.init', callback);
     },
-    init: ['beforeInit', function(results, callback) {
+    cliParse: ['beforeInit', function(results, callback) {
       _parseCommandLine();
+      events.emit('bedrock-cli.parsed', callback);
+    }],
+    init: ['cliParse', function(results, callback) {
       _loadConfigs();
       _configureLoggers();
       _configureWorkers();

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -1,23 +1,23 @@
 /*
  * Copyright (c) 2012-2016 Digital Bazaar, Inc. All rights reserved.
  */
-var async = require('async');
-var brUtil = require('./util');
-var cc = brUtil.config.main.computer();
-var cluster = require('cluster');
-var config = require('./config');
-var errio = require('errio');
-var events = require('./events');
-var jsonld = require('./jsonld');
-var loggers = require('./loggers');
-var path = require('path');
-var pkginfo = require('pkginfo');
-var program = require('commander');
-var test = require('./test');
+const async = require('async');
+const brUtil = require('./util');
+const cc = brUtil.config.main.computer();
+const cluster = require('cluster');
+const config = require('./config');
+const errio = require('errio');
+const events = require('./events');
+const jsonld = require('./jsonld');
+const loggers = require('./loggers');
+const path = require('path');
+const pkginfo = require('pkginfo');
+const program = require('commander');
+const test = require('./test');
 const BedrockError = brUtil.BedrockError;
 
 // core API
-var api = {};
+const api = {};
 api.config = config;
 api.events = events;
 api.jsonld = jsonld;
@@ -89,7 +89,7 @@ api.start = function(options, done) {
   }
   options = options || {};
 
-  var startTime = Date.now();
+  const startTime = Date.now();
 
   function collect(val, memo) {
     memo.push(val);
@@ -188,7 +188,7 @@ api.setProcessUser = function() {
   // send message to master
   process.send({type: 'bedrock.switchProcessUser'});
 };
-var _switchedProcessUser = false;
+let _switchedProcessUser = false;
 
 /**
  * Called from a worker to executes the given function in only one worker.
@@ -213,7 +213,7 @@ api.runOnce = function(id, fn, options, callback) {
   // listen to run function once
   process.on('message', runOnce);
 
-  var ran = false;
+  const ran = false;
   function runOnce(msg) {
     // ignore other messages
     if(!_isMessageType(msg, 'bedrock.runOnce') || msg.id !== id) {
@@ -230,10 +230,10 @@ api.runOnce = function(id, fn, options, callback) {
       return callback(msg.error, ran);
     }
 
-    var _callback = function(err) {
-      var _msg = {
+    const _callback = function(err) {
+      const _msg = {
         type: 'bedrock.runOnce',
-        id: id,
+        id,
         done: true
       };
       if(err) {
@@ -255,7 +255,7 @@ api.runOnce = function(id, fn, options, callback) {
   }
 
   // schedule function to run
-  process.send({type: 'bedrock.runOnce', id: id, options: options});
+  process.send({type: 'bedrock.runOnce', id, options});
 };
 
 /**
@@ -299,17 +299,17 @@ function _configureLoggers() {
   }
   // adjust transports
   if('logTransports' in program) {
-    var t = program.logTransports;
-    var cats = t.split(',');
+    const t = program.logTransports;
+    const cats = t.split(',');
     cats.forEach(function(cat) {
-      var catName = cat.split('=')[0];
-      var catTransports;
+      const catName = cat.split('=')[0];
+      let catTransports;
       if(catName in config.loggers.categories) {
         catTransports = config.loggers.categories[catName];
       } else {
         catTransports = config.loggers.categories[catName] = [];
       }
-      var transports = cat.split('=')[1].split(';');
+      const transports = cat.split('=')[1].split(';');
       transports.forEach(function(transport) {
         if(transport.indexOf('-') === 0) {
           const tName = transport.slice(1);
@@ -393,9 +393,9 @@ function _setupUncaughtExceptionHandler(mode, logger) {
 
 function _runMaster(options) {
   // get starting script
-  var script = options.script || process.argv[1];
+  const script = options.script || process.argv[1];
 
-  var logger = loggers.get('app');
+  const logger = loggers.get('app');
   logger.info('starting bedrock...');
 
   // setup cluster if running with istanbul coverage
@@ -411,7 +411,7 @@ function _runMaster(options) {
   }
 
   // set 'ps' title
-  var args = process.argv.slice(2).join(' ');
+  const args = process.argv.slice(2).join(' ');
   process.title = config.core.master.title + (args ? (' ' + args) : '');
 
   _setupUncaughtExceptionHandler('master', logger);
@@ -420,14 +420,14 @@ function _runMaster(options) {
     config.core.master.title + '"', {pid: process.pid});
 
   // keep track of master state
-  var masterState = {
+  const masterState = {
     switchedUser: false,
     runOnce: {}
   };
 
   // notify workers to exit if master exits
   process.on('exit', function() {
-    for(var id in cluster.workers) {
+    for(const id in cluster.workers) {
       cluster.workers[id].send({type: 'bedrock.core', message: 'exit'});
     }
   });
@@ -450,7 +450,7 @@ function _runMaster(options) {
     // if configured, fork a replacement worker
     if(config.core.worker.restart) {
       // clear any runOnce records w/allowOnRestart option set
-      for(var id in masterState.runOnce) {
+      for(const id in masterState.runOnce) {
         if(masterState.runOnce[id].worker === worker.id &&
           masterState.runOnce[id].options.allowOnRestart) {
           delete masterState.runOnce[id];
@@ -463,17 +463,17 @@ function _runMaster(options) {
   });
 
   // fork each app process
-  var workers = config.core.workers;
-  for(var i = 0; i < workers; ++i) {
+  const workers = config.core.workers;
+  for(let i = 0; i < workers; ++i) {
     _startWorker(masterState, script);
   }
 }
 
 function _runWorker(startTime, done) {
-  var logger = loggers.get('app');
+  const logger = loggers.get('app');
 
   // set 'ps' title
-  var args = process.argv.slice(2).join(' ');
+  const args = process.argv.slice(2).join(' ');
   process.title = config.core.worker.title + (args ? (' ' + args) : '');
 
   _setupUncaughtExceptionHandler('worker', logger);
@@ -482,7 +482,7 @@ function _runWorker(startTime, done) {
     config.core.worker.title + '"');
 
   // listen for master process exit
-  var bedrockStarted = false;
+  let bedrockStarted = false;
   process.on('message', function(msg) {
     if(!_isMessageType(msg, 'bedrock.core') || msg.message !== 'exit') {
       return;
@@ -528,7 +528,7 @@ function _runWorker(startTime, done) {
       events.emit('bedrock.start', callback);
     }],
     ready: ['start', function(results, callback) {
-      var dtTime = Date.now() - startTime;
+      const dtTime = Date.now() - startTime;
       logger.info('startup time: ' + dtTime + 'ms');
       events.emit('bedrock.ready', callback);
     }],
@@ -541,7 +541,7 @@ function _runWorker(startTime, done) {
 }
 
 function _startWorker(state, script) {
-  var worker = cluster.fork();
+  const worker = cluster.fork();
   loggers.attach(worker);
 
   // listen to start requests from workers
@@ -557,7 +557,7 @@ function _startWorker(state, script) {
     worker.send({
       type: 'bedrock.worker.init',
       cwd: process.cwd(),
-      script: script
+      script
     });
   }
 
@@ -602,9 +602,9 @@ function _startWorker(state, script) {
       state.runOnce[msg.id].done = true;
       state.runOnce[msg.id].error = msg.error || null;
       // notify workers to call callback
-      var notify = state.runOnce[msg.id].notify;
+      const notify = state.runOnce[msg.id].notify;
       while(notify.length > 0) {
-        var id = notify.shift();
+        const id = notify.shift();
         if(id in cluster.workers) {
           cluster.workers[id].send({
             type: 'bedrock.runOnce',

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -1,6 +1,8 @@
-/*
- * Copyright (c) 2012-2016 Digital Bazaar, Inc. All rights reserved.
+/*!
+ * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
+'use strict';
+
 const async = require('async');
 const brUtil = require('./util');
 const cc = brUtil.config.main.computer();

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,8 @@
-/*
- * Copyright (c) 2012-2015 Digital Bazaar, Inc. All rights reserved.
+/*!
+ * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
+'use strict';
+
 const config = {};
 module.exports = config;
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,8 +1,7 @@
 /*
  * Copyright (c) 2012-2015 Digital Bazaar, Inc. All rights reserved.
  */
-var config = {};
-var path = require('path');
+const config = {};
 module.exports = config;
 
 // cli info

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,6 +1,8 @@
-/*
- * Copyright (c) 2012-2015 Digital Bazaar, Inc. All rights reserved.
+/*!
+ * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
+'use strict';
+
 const events = {
   EventEmitter: require('async-node-events')
 };

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,17 +1,17 @@
 /*
  * Copyright (c) 2012-2015 Digital Bazaar, Inc. All rights reserved.
  */
-var events = {
+const events = {
   EventEmitter: require('async-node-events')
 };
 
-var api = new events.EventEmitter();
+const api = new events.EventEmitter();
 api.setMaxListeners(0);
 api.removeAllListeners('maxListenersPassed');
 module.exports = api;
 
 // store original emit function
-var emit = api.emit;
+const emit = api.emit;
 
 /**
  * Emits an event just like the standard EventEmitter does, however, if the

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2013-2015 Digital Bazaar, Inc. All rights reserved.
  */
-var config = require('./config');
-var constants = config.constants;
-var events = require('./events');
-var jsonld = require('jsonld')(); // use localized jsonld API
+const config = require('./config');
+const constants = config.constants;
+const events = require('./events');
+const jsonld = require('jsonld')(); // use localized jsonld API
 
 events.on('bedrock.init', function() {
   // require https for @contexts
-  var options = {secure: true};
+  const options = {secure: true};
 
   // set strictSSL option if configured
   if('strictSSL' in config.jsonld) {
     options.strictSSL = config.jsonld.strictSSL;
   }
 
-  var nodeDocumentLoader = jsonld.documentLoaders.node(options);
+  const nodeDocumentLoader = jsonld.documentLoaders.node(options);
 
   jsonld.documentLoader = function(url, callback) {
     if(url in constants.CONTEXTS) {
@@ -32,7 +32,7 @@ events.on('bedrock.init', function() {
 
 // setup initial temporary document loader to log warning if it's used before
 // jsonld is configured
-var defaultDocumentLoader = jsonld.documentLoader;
+const defaultDocumentLoader = jsonld.documentLoader;
 jsonld.documentLoader = function(url, callback) {
   // FIXME: improve warning logging method (if even needed?)
   // Could possibly be run too early to easily use bedrock logging system.

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -1,6 +1,8 @@
-/*
- * Copyright (c) 2013-2015 Digital Bazaar, Inc. All rights reserved.
+/*!
+ * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
+'use strict';
+
 const config = require('./config');
 const constants = config.constants;
 const events = require('./events');

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -1,6 +1,8 @@
-/*
- * Copyright (c) 2012-2016 Digital Bazaar, Inc. All rights reserved.
+/*!
+ * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
+'use strict';
+
 const async = require('async');
 const brUtil = require('./util');
 const cc = brUtil.config.main.computer();

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -1,22 +1,23 @@
 /*
  * Copyright (c) 2012-2016 Digital Bazaar, Inc. All rights reserved.
  */
-var async = require('async');
-var brUtil = require('./util');
-var cc = brUtil.config.main.computer();
-var cluster = require('cluster');
-var config = require('./config');
-var cycle = require('cycle');
-var fs = require('fs');
-var mkdirp = require('mkdirp');
-var path = require('path');
-var util = require('util');
-var winston = require('winston');
-var WinstonMail = require('winston-mail').Mail;
+const async = require('async');
+const brUtil = require('./util');
+const cc = brUtil.config.main.computer();
+const cluster = require('cluster');
+const config = require('./config');
+const cycle = require('cycle');
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+const path = require('path');
+const util = require('util');
+const winston = require('winston');
+const WinstonMail = require('winston-mail').Mail;
 
 // posix isn't available on Windows, ignore it silently
+let posix;
 try {
-  var posix = require('posix');
+  posix = require('posix');
 } catch(e) {
   posix = null;
 }
@@ -30,7 +31,7 @@ cc({
 });
 
 // create custom logging levels
-var levels = {
+const levels = {
   silly: 0,
   verbose: 1,
   debug: 2,
@@ -39,7 +40,7 @@ var levels = {
   error: 5,
   critical: 6
 };
-var colors = {
+const colors = {
   silly: 'cyan',
   verbose: 'blue',
   debug: 'blue',
@@ -50,7 +51,7 @@ var colors = {
 };
 
 // create the container for the master and all of the workers
-var container = new winston.Container();
+const container = new winston.Container();
 // override get to use a wrapper so loggers that are retrieved via `.get()`
 // prior to logger initialization will receive the updated configuration
 // when logging after initialization
@@ -97,9 +98,9 @@ if(cluster.isMaster) {
 
 function chown(filename, callback) {
   if(config.core.running.userId) {
-    var uid = config.core.running.userId;
+    let uid = config.core.running.userId;
     if(typeof uid !== 'number') {
-      var user = null;
+      let user = null;
       if(posix) {
         user = posix.getpwnam(uid);
       } else if(process.platform === 'win32') {
@@ -181,7 +182,7 @@ class ModuleFileTransport extends winston.transports.File {
 container.init = function(callback) {
   if(cluster.isMaster) {
     // create shared transports
-    var transports = container.transports;
+    const transports = container.transports;
     transports.console = new ModuleConsoleTransport(config.loggers.console);
     transports.app = new ModuleFileTransport(config.loggers.app);
     transports.access = new ModuleFileTransport(config.loggers.access);
@@ -197,14 +198,14 @@ container.init = function(callback) {
       function(callback) {
         // ensure all files are created and have ownership set to the
         // application process user
-        var fileLoggers = Object.keys(config.loggers).filter(function(name) {
-          var logger = config.loggers[name];
+        const fileLoggers = Object.keys(config.loggers).filter(function(name) {
+          const logger = config.loggers[name];
           return (brUtil.isObject(logger) && 'filename' in logger);
         }).map(function(name) {
           return config.loggers[name];
         });
         async.each(fileLoggers, function(fileLogger, callback) {
-          var dirname = path.dirname(fileLogger.filename);
+          const dirname = path.dirname(fileLogger.filename);
           async.waterfall([
             // make directory and chown if requested
             async.apply(mkdirp.mkdirp, dirname),
@@ -224,18 +225,18 @@ container.init = function(callback) {
       },
       function(callback) {
         // create master loggers
-        for(var cat in config.loggers.categories) {
-          var transportNames = config.loggers.categories[cat];
-          var options = {transports: []};
+        for(const cat in config.loggers.categories) {
+          const transportNames = config.loggers.categories[cat];
+          const options = {transports: []};
           transportNames.forEach(function(name) {
             options.transports.push(transports[name]);
           });
-          var logger = new winston.Logger(options);
+          const logger = new winston.Logger(options);
           logger.setLevels(levels);
           if(container.loggers[cat]) {
             container.loggers[cat].__proto__ = logger;
           } else {
-            var wrapper = {};
+            const wrapper = {};
             wrapper.__proto__ = logger;
             container.loggers[cat] = wrapper;
           }
@@ -268,7 +269,7 @@ container.init = function(callback) {
   // workers:
 
   // define transport that transmits log message to master logger
-  var WorkerTransport = function(options) {
+  const WorkerTransport = function(options) {
     winston.Transport.call(this, options);
     this.category = options.category;
   };
@@ -285,7 +286,7 @@ container.init = function(callback) {
     // pull out any meta values that are pre-formatted
     meta = meta || {};
     let preformatted = null;
-    let metaIsObject = brUtil.isObject(meta);
+    const metaIsObject = brUtil.isObject(meta);
     let module = null;
     if(metaIsObject) {
       if('preformatted' in meta) {
@@ -307,10 +308,10 @@ container.init = function(callback) {
     let error;
     if(meta instanceof Error) {
       error = ('stack' in meta) ? meta.stack : meta;
-      meta = {error: error, workerPid: process.pid};
+      meta = {error, workerPid: process.pid};
     } else if(metaIsObject && 'error' in meta) {
       error = ('stack' in meta.error) ? meta.error.stack : meta.error;
-      meta = {error: error, workerPid: process.pid};
+      meta = {error, workerPid: process.pid};
     } else {
       meta = {workerPid: process.pid};
     }
@@ -333,9 +334,9 @@ container.init = function(callback) {
     // send logger message to master
     process.send({
       type: 'bedrock.logger',
-      level: level,
-      msg: msg,
-      meta: meta,
+      level,
+      msg,
+      meta,
       category: this.category
     });
     this.emit('logged');
@@ -343,16 +344,16 @@ container.init = function(callback) {
   };
 
   // create worker loggers
-  var lowestLevel = Object.keys(levels)[0];
-  for(var cat in config.loggers.categories) {
-    var logger = new winston.Logger({
+  const lowestLevel = Object.keys(levels)[0];
+  for(const cat in config.loggers.categories) {
+    const logger = new winston.Logger({
       transports: [new WorkerTransport({level: lowestLevel, category: cat})]
     });
     logger.setLevels(levels);
     if(container.loggers[cat]) {
       container.loggers[cat].__proto__ = logger;
     } else {
-      var wrapper = {};
+      const wrapper = {};
       wrapper.__proto__ = logger;
       container.loggers[cat] = wrapper;
     }

--- a/lib/test.config.js
+++ b/lib/test.config.js
@@ -1,4 +1,4 @@
-var config = require('./config');
+const config = require('./config');
 
 // logging
 config.loggers.app.filename = '/tmp/bedrock-test-app.log';

--- a/lib/test.config.js
+++ b/lib/test.config.js
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
 const config = require('./config');
 
 // logging

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,6 +1,8 @@
-/*
- * Copyright (c) 2012-2017 Digital Bazaar, Inc. All rights reserved.
+/*!
+ * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
+'use strict';
+
 const config = require('./config');
 const events = require('./events');
 const path = require('path');

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,8 @@
-/*
- * Copyright (c) 2012-2016 Digital Bazaar, Inc. All rights reserved.
+/*!
+ * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
+'use strict';
+
 const _ = require('lodash');
 const config = require('./config');
 const util = require('util');

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2012-2016 Digital Bazaar, Inc. All rights reserved.
  */
-var _ = require('lodash');
-var config = require('./config');
-var util = require('util');
-var jsonld = require('./jsonld'); // use locally-configured jsonld
+const _ = require('lodash');
+const config = require('./config');
+const util = require('util');
+const jsonld = require('./jsonld'); // use locally-configured jsonld
 
-var api = {};
+const api = {};
 module.exports = api;
 
 // BedrockError class
@@ -25,7 +25,7 @@ api.BedrockError.prototype.toObject = function(options) {
   options.public = options.public || false;
 
   // convert error to object
-  var rval = _toObject(this, options);
+  const rval = _toObject(this, options);
 
   // add stack trace only for non-public development conversion
   if(!options.public && config.core.errors.showStack) {
@@ -51,13 +51,13 @@ api.BedrockError.prototype.hasCauseOfType = function(type) {
   return false;
 };
 
-var _genericErrorJSON = {
+const _genericErrorJSON = {
   message: 'An internal server error occurred.',
   type: 'bedrock.InternalServerError'
 };
 
-var _errorMessageRegex = /^Error:\s*/;
-var _errorAtRegex = /^\s+at\s*/;
+const _errorMessageRegex = /^Error:\s*/;
+const _errorAtRegex = /^\s+at\s*/;
 /**
  * Parse an Error stack property into a JSON structure.
  *
@@ -67,11 +67,11 @@ var _errorAtRegex = /^\s+at\s*/;
  */
 function _parseStack(stack) {
   try {
-    var lines = stack.split('\n');
-    var messageLines = [];
-    var atLines = [];
-    for(var i = 0; i < lines.length; ++i) {
-      var line = lines[i];
+    const lines = stack.split('\n');
+    const messageLines = [];
+    const atLines = [];
+    for(let i = 0; i < lines.length; ++i) {
+      const line = lines[i];
       // push location-like lines to a stack array
       if(line.match(_errorAtRegex)) {
         atLines.push(line.replace(_errorAtRegex, ''));
@@ -100,10 +100,10 @@ function _toObject(err, options) {
     // FIXME also check if a validation type?
     if(err instanceof api.BedrockError &&
       err.details && err.details.public) {
-      var details = api.clone(err.details);
+      const details = api.clone(err.details);
       delete details.public;
       // mask cause if it is not a public bedrock error
-      var cause = err.cause;
+      let {cause} = err;
       if(!(cause && cause instanceof api.BedrockError &&
         cause.details && cause.details.public)) {
         cause = null;
@@ -111,7 +111,7 @@ function _toObject(err, options) {
       return {
         message: err.message,
         type: err.name,
-        details: details,
+        details,
         cause: _toObject(cause, options)
       };
     } else {
@@ -177,18 +177,18 @@ function _zeroFill(num) {
  * @return the default Bedrock JSON-LD context.
  */
 api.extend = function() {
-  var deep = false;
-  var i = 0;
+  let deep = false;
+  let i = 0;
   if(arguments.length > 0 && typeof arguments[0] === 'boolean') {
     deep = arguments[0];
     ++i;
   }
-  var target = arguments[i] || {};
+  const target = arguments[i] || {};
   i++;
   for(; i < arguments.length; ++i) {
-    var obj = arguments[i] || {};
+    const obj = arguments[i] || {};
     Object.keys(obj).forEach(function(name) {
-      var value = obj[name];
+      const value = obj[name];
       if(deep && api.isObject(value) && !Array.isArray(value)) {
         target[name] = api.extend(true, target[name], value);
       } else {
@@ -219,15 +219,15 @@ api.isObject = function(value) {
  */
 api.clone = function(value) {
   if(value && typeof value === 'object') {
-    var rval;
+    let rval;
     if(Array.isArray(value)) {
       rval = new Array(value.length);
-      for(var i = 0; i < rval.length; i++) {
+      for(let i = 0; i < rval.length; i++) {
         rval[i] = api.clone(value[i]);
       }
     } else {
       rval = {};
-      for(var j in value) {
+      for(const j in value) {
         rval[j] = api.clone(value[j]);
       }
     }
@@ -313,7 +313,7 @@ api.config.Config.prototype.set = function(path, value) {
  */
 api.config.Config.prototype.setDefault = function(path, value) {
   if(!_isPath(path)) {
-    var paths = {};
+    const paths = {};
     Object.keys(path).forEach((key) => {
       paths[key] = _setDefault(this.object, key, path[key]);
     });
@@ -341,50 +341,51 @@ api.config.Config.prototype.setDefault = function(path, value) {
  */
 api.config.Config.prototype.setComputed =
   function(path, fnOrExpression, options) {
-  if(!_isPath(path)) {
-    options = fnOrExpression;
-    Object.keys(path).forEach(key => this.setComputed(key, path[key], options));
-    return;
-  }
-  if(typeof fnOrExpression === 'string') {
-    // handle strings as templates
-    fnOrExpression = _.template(fnOrExpression);
-  } else if(typeof fnOrExpression !== 'function') {
-    // handle non-string non-functions as simple values
-    return this.set(path, fnOrExpression);
-  }
-  // ensure path is array
-  if(typeof path === 'string') {
-    path = _.toPath(path);
-  }
-  // locals
-  options = options || {};
-  var locals = options.locals || this.options.locals || config;
-  // get target object path
-  var targetPath = path.slice(0, -1);
-  // get key
-  var targetKey = path.slice(-1);
-  // get or create target parent object
-  var parentDefault = options.parentDefault || {};
-  var target = _setDefault(this.object, targetPath, parentDefault);
-  // setup property
-  var _isSet = false;
-  var _value;
-  Object.defineProperty(target, targetKey, {
-    configurable: true,
-    enumerable: true,
-    get: () => {
-      if(_isSet) {
-        return _value;
-      }
-      return fnOrExpression(locals);
-    },
-    set: (value) => {
-      _isSet = true;
-      _value = value;
+    if(!_isPath(path)) {
+      options = fnOrExpression;
+      Object.keys(path).forEach(key => this.setComputed(
+        key, path[key], options));
+      return;
     }
-  });
-};
+    if(typeof fnOrExpression === 'string') {
+      // handle strings as templates
+      fnOrExpression = _.template(fnOrExpression);
+    } else if(typeof fnOrExpression !== 'function') {
+      // handle non-string non-functions as simple values
+      return this.set(path, fnOrExpression);
+    }
+    // ensure path is array
+    if(typeof path === 'string') {
+      path = _.toPath(path);
+    }
+    // locals
+    options = options || {};
+    const locals = options.locals || this.options.locals || config;
+    // get target object path
+    const targetPath = path.slice(0, -1);
+    // get key
+    const targetKey = path.slice(-1);
+    // get or create target parent object
+    const parentDefault = options.parentDefault || {};
+    const target = _setDefault(this.object, targetPath, parentDefault);
+    // setup property
+    let _isSet = false;
+    let _value;
+    Object.defineProperty(target, targetKey, {
+      configurable: true,
+      enumerable: true,
+      get: () => {
+        if(_isSet) {
+          return _value;
+        }
+        return fnOrExpression(locals);
+      },
+      set: (value) => {
+        _isSet = true;
+        _value = value;
+      }
+    });
+  };
 
 /**
  * Create a bound setComputed function for this Config instance. Used to
@@ -411,16 +412,16 @@ api.config.Config.prototype.computer = function() {
  */
 api.config.Config.prototype.pushComputed =
   function(path, fnOrExpression, options) {
-  // get target or default array
-  let target = _.get(this.object, path, []);
-  // add next index
-  let pushPath = _.toPath(path);
-  pushPath.push(target.length);
-  // use default parent array
-  let pushOptions = Object.assign({}, options, {parentDefault: []});
-  // set computed array element
-  this.setComputed(pushPath, fnOrExpression, pushOptions);
-};
+    // get target or default array
+    const target = _.get(this.object, path, []);
+    // add next index
+    const pushPath = _.toPath(path);
+    pushPath.push(target.length);
+    // use default parent array
+    const pushOptions = Object.assign({}, options, {parentDefault: []});
+    // set computed array element
+    this.setComputed(pushPath, fnOrExpression, pushOptions);
+  };
 
 /**
  * Shared wrapper for the standard bedrock config.

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,6 +1,8 @@
-/*
- * Copyright (c) 2012-2015 Digital Bazaar, Inc. All rights reserved.
+/*!
+ * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
+'use strict';
+
 // wait for initialization options from master
 process.on('message', init);
 

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,6 +1,9 @@
 {
   "env": {
-    "mocha": true,
-    "ecmaVersion": 2015
+    "mocha": true
+  },
+  "globals": {
+    "assertNoError": true,
+    "should": true
   }
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,7 +1,6 @@
-/*
- * Copyright (c) 2012-2015 Digital Bazaar, Inc. All rights reserved.
+/*!
+ * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
-
 'use strict';
 
 const bedrock = require('../lib/bedrock');

--- a/tests/test.js
+++ b/tests/test.js
@@ -4,36 +4,36 @@
 
 'use strict';
 
-var bedrock = require('../lib/bedrock');
-var BedrockError = bedrock.util.BedrockError;
+const bedrock = require('../lib/bedrock');
+const BedrockError = bedrock.util.BedrockError;
 
 describe('bedrock', function() {
   describe('util.extend()', function() {
     it('should perform in-place default extension', function(done) {
-      var result = {};
+      const result = {};
       bedrock.util.extend(result, {a: 1});
       result.should.eql({a: 1});
       done();
     });
     it('should perform in-place deep extension', function(done) {
-      var result = {a: {a0: 0}, b: 2};
+      const result = {a: {a0: 0}, b: 2};
       bedrock.util.extend(true, result, {a: {a1: 1}});
       result.should.eql({a: {a0: 0, a1: 1}, b: 2});
       done();
     });
     it('should perform in-place shallow extension', function(done) {
-      var result = {a: {a0: 0}, b: 2};
+      const result = {a: {a0: 0}, b: 2};
       bedrock.util.extend(false, result, {a: {a1: 1}});
       result.should.eql({a: {a1: 1}, b: 2});
       done();
     });
     it('should be able to return a new object', function(done) {
-      var result = bedrock.util.extend(true, {}, {a: 1});
+      const result = bedrock.util.extend(true, {}, {a: 1});
       result.should.eql({a: 1});
       done();
     });
     it('should merge multiple objects into a new object', function(done) {
-      var result = {};
+      const result = {};
       bedrock.util.extend(true, result, {a: 1}, {b: 2});
       result.should.eql({a: 1, b: 2});
       done();
@@ -42,7 +42,7 @@ describe('bedrock', function() {
 
   describe('util.BedrockError', function() {
     it('should have correct type', function(done) {
-      var err = new BedrockError('E', 'TYPE', null, null);
+      const err = new BedrockError('E', 'TYPE', null, null);
       err.isType('BOGUS').should.be.false;
       err.isType('TYPE').should.be.true;
       err.hasType('BOGUS').should.be.false;
@@ -50,8 +50,8 @@ describe('bedrock', function() {
       done();
     });
     it('should have correct cause', function(done) {
-      var err0 = new BedrockError('E0', 'E0TYPE', null, null);
-      var err1 = new BedrockError('E1', 'E1TYPE', null, err0);
+      const err0 = new BedrockError('E0', 'E0TYPE', null, null);
+      const err1 = new BedrockError('E1', 'E1TYPE', null, err0);
       err1.isType('BOGUS').should.be.false;
       err1.isType('E1TYPE').should.be.true;
       err1.hasType('BOGUS').should.be.false;
@@ -71,7 +71,7 @@ describe('bedrock', function() {
         // 'base' used for path testing
         base: {}
       };
-      let options = {
+      const options = {
         // set locals to our custom config root
         locals: config
       };
@@ -113,7 +113,7 @@ describe('bedrock', function() {
     describe('basic setDefault functionality', function() {
       it('should setDefault when exists', function() {
         (typeof config.p1).should.equal('undefined');
-        var object = c.setDefault('p1', {});
+        const object = c.setDefault('p1', {});
         config.p1.should.equal(object);
         Object.keys(object).length.should.equal(0);
       });
@@ -121,21 +121,21 @@ describe('bedrock', function() {
         config.p1 = {};
         config.p1.exists = true;
         config.p1.exists.should.equal(true);
-        var object = c.setDefault('p1', {});
+        const object = c.setDefault('p1', {});
         config.p1.should.equal(object);
         config.p1.should.equal(config.p1);
         config.p1.exists.should.equal(true);
       });
       it('should setDefault paths', function() {
         (typeof config.p1).should.equal('undefined');
-        var object = c.setDefault('p1.p2', {});
+        const object = c.setDefault('p1.p2', {});
         config.p1.p2.should.equal(object);
         Object.keys(config.p1).length.should.equal(1);
         Object.keys(config.p1.p2).length.should.equal(0);
       });
       it('should setDefault array paths', function() {
         (typeof config.p1).should.equal('undefined');
-        var object = c.setDefault(['p1', 'p2'], {});
+        const object = c.setDefault(['p1', 'p2'], {});
         config.p1.p2.should.equal(object);
         Object.keys(config.p1).length.should.equal(1);
         Object.keys(config.p1.p2).length.should.equal(0);
@@ -146,7 +146,7 @@ describe('bedrock', function() {
         (typeof config.p2).should.equal('undefined');
         (typeof config.p3).should.equal('object');
         Object.keys(config.p3).length.should.equal(0);
-        var object = c.setDefault({
+        const object = c.setDefault({
           'p1': {},
           'p2.c1': {},
           'p3.c1': {}
@@ -276,7 +276,7 @@ describe('bedrock', function() {
 
     describe('default config', function() {
       // computed config for main config
-      let _cc = bedrock.util.config.main.computer();
+      const _cc = bedrock.util.config.main.computer();
 
       // ensure empty config container
       beforeEach('create config', function() {
@@ -288,7 +288,7 @@ describe('bedrock', function() {
       });
 
       it('should use default config', function() {
-        let config = bedrock.config;
+        const config = bedrock.config;
         config._mocha.a = 'a';
         config._mocha.b = 'b';
         _cc('_mocha.computed', () => config._mocha.a + config._mocha.b);
@@ -298,32 +298,32 @@ describe('bedrock', function() {
 
     describe('templates', function() {
       it('should create', function() {
-        let _options = {locals: config};
-        let _cc = new bedrock.util.config.Config(config, _options).computer();
+        const _options = {locals: config};
+        const _cc = new bedrock.util.config.Config(config, _options).computer();
         config.base.a = 'a';
         config.base.b = 'b';
         _cc('computed', '${base.a + base.b}', _options);
         config.computed.should.equal('ab');
       });
       it('should create with custom locals', function() {
-        let _options = {locals: config.base};
-        let _cc = new bedrock.util.config.Config(config, _options).computer();
+        const _options = {locals: config.base};
+        const _cc = new bedrock.util.config.Config(config, _options).computer();
         config.base.a = 'a';
         config.base.b = 'b';
         _cc('computed', '${a + b}');
         config.computed.should.equal('ab');
       });
       it('should create with per-call locals', function() {
-        let _options = {locals: config.base};
-        let _cc = new bedrock.util.config.Config(config).computer();
+        const _options = {locals: config.base};
+        const _cc = new bedrock.util.config.Config(config).computer();
         config.base.a = 'a';
         config.base.b = 'b';
         _cc('computed', '${a + b}', _options);
         config.computed.should.equal('ab');
       });
       it('should update', function() {
-        let _options = {locals: config};
-        let _cc = new bedrock.util.config.Config(config, _options).computer();
+        const _options = {locals: config};
+        const _cc = new bedrock.util.config.Config(config, _options).computer();
         config.base.a = 'a';
         config.base.b = 'b';
         _cc('computed', '${base.a + base.b}');
@@ -461,7 +461,7 @@ describe('bedrock', function() {
         c.setDefault('accounts.admin', {});
         config.accounts.admin.name = 'Ima Admin';
         c.set('accounts.admin.id', 1);
-        let account123 = c.setDefault('accounts.account123', {});
+        const account123 = c.setDefault('accounts.account123', {});
         account123.id = 123;
         account123.name = 'Account 123';
 
@@ -595,10 +595,10 @@ describe('bedrock', function() {
 
     describe('examples', function() {
       it('should support an example', function() {
-        let config = {};
-        let options = {config: config, locals: config};
-        let c = new bedrock.util.config.Config(config, options);
-        let cc = c.computer();
+        const config = {};
+        const options = {config, locals: config};
+        const c = new bedrock.util.config.Config(config, options);
+        const cc = c.computer();
         c.set('server.port', 8443);
         // direct access, 'server' container known to exist
         config.server.domain = 'bedrock.dev';
@@ -613,10 +613,10 @@ describe('bedrock', function() {
         // use Config.setComputed API
         c.setComputed('server.baseUri1', 'https://${server.host}');
         // bind setComputed
-        let cc2 = c.setComputed.bind(c);
+        const cc2 = c.setComputed.bind(c);
         cc2('server.baseUri2', 'https://${server.host}');
         // use binding API
-        let cc3 = c.computer();
+        const cc3 = c.computer();
         cc3('server.baseUri3', 'https://${server.host}');
 
         // all should have the same value
@@ -637,7 +637,7 @@ describe('bedrock', function() {
 // TODO: add test that adds logger early
 
 /*
-var winston = require('winston');
+const winston = require('winston');
 
 bedrock.events.on('bedrock-cli.init', function() {
   // TODO: test w/custom logger that writes to string, not file


### PR DESCRIPTION
From the readme:

- **bedrock-cli.parsed**
  - Emitted after command line parsing. Allows for configuration of loggers
    based on command line flags. For instance, a logger may provide for the
    specification of a `logGroupName` that may be computed at runtime based
    on some command line flag(s).