### PR TITLE
Default `jsonld.strictSSL` to true.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # bedrock ChangeLog
 
+## 1.13.1 - TBD
+
+### Changed
+- change default value of `bedrock.config.jsonld.strictSSL` from `false` to
+  `true`. This means that the `jsonld` library's document loader will refuse
+  to retrieve documents from sites without proper SSL certificates. This change
+  will impact unit tests in Bedrock modules. The `strictSSL` flag will need to
+  be set to `false` in the `test.config.js` files for affected modules.
+
 ## 1.13.0 - 2018-09-20
 
 ## Added

--- a/lib/config.js
+++ b/lib/config.js
@@ -65,8 +65,7 @@ config.constants.CONTEXTS = {};
 
 // jsonld
 config.jsonld = {};
-// FIXME: Change to true. Could break projects expecting a default of false.
-config.jsonld.strictSSL = false;
+config.jsonld.strictSSL = true;
 
 // logging
 config.loggers = {};


### PR DESCRIPTION
Fixes #3.

@digitalbazaar/dev please acknowledge that you have read and understand the change described in the changelog.  If you encounter a module where the test suite is failing unexpectedly, this change is a likely culprit.  Please make the necessary updates to the `test..config.js` file and submit a PR.