### PR TITLE
Implement runOnceAsync.

### DIFF
--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -193,7 +193,7 @@ api.setProcessUser = function() {
 };
 
 /**
- * Called from a worker to executes the given function in only one worker.
+ * Called from a worker to execute the given function in only one worker.
  *
  * @param id a unique identifier for the function to execute.
  * @param fn the function to execute; if it takes a parameter, it will be
@@ -261,7 +261,7 @@ api.runOnce = function(id, fn, options, callback) {
 };
 
 /**
- * Called from a worker to executes the given function in only one worker.
+ * Called from a worker to execute the given function in only one worker.
  *
  * @param {string} id -  a unique identifier for the function to execute.
  * @param {Function} fn - The async function to execute.

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -260,6 +260,50 @@ api.runOnce = function(id, fn, options, callback) {
   process.send({type: 'bedrock.runOnce', id, options});
 };
 
+api.runOnceAsync = async (id, fn, options = {}) => {
+  const promise = new Promise((resolve, reject) => {
+    // listen to run function once
+    process.on('message', _runOnce);
+
+    // const ran = false;
+    async function _runOnce(msg) {
+      // ignore other messages
+      if(!(_isMessageType(msg, 'bedrock.runOnceAsync') && msg.id === id)) {
+        return;
+      }
+
+      process.removeListener('bedrock.runOnceAsync', _runOnce);
+
+      if(msg.error) {
+        return reject(errio.fromObject(msg.error, {stack: true}));
+      }
+
+      if(msg.done) {
+        // FIXME: what's going on with `ran`?
+        return resolve();
+        // return resolve(msg.error, ran);
+      }
+
+      // run in this worker
+      const _msg = {
+        type: 'bedrock.runOnceAsync',
+        id,
+        done: true
+      };
+      try {
+        await fn();
+      } catch(e) {
+        _msg.error = errio.toObject(e, {stack: true});
+      }
+      process.send(_msg);
+    } // end _runOnce
+  });
+
+  // schedule function to run
+  process.send({type: 'bedrock.runOnceAsync', id, options});
+  return promise;
+};
+
 /**
  * Called from a worker to exit gracefully. Typically used by subcommands.
  */
@@ -644,6 +688,57 @@ function _startWorker(state, script) {
       error: null
     };
     worker.send({type: 'bedrock.runOnce', id: msg.id, done: false});
+  });
+
+  worker.on('message', function(msg) {
+    if(!_isMessageType(msg, 'bedrock.runOnceAsync')) {
+      return;
+    }
+
+    if(msg.done) {
+      state.runOnce[msg.id].done = true;
+      state.runOnce[msg.id].error = msg.error || null;
+      // notify workers to call callback
+      const notify = state.runOnce[msg.id].notify;
+      while(notify.length > 0) {
+        const id = notify.shift();
+        if(id in cluster.workers) {
+          cluster.workers[id].send({
+            type: 'bedrock.runOnceAsync',
+            id: msg.id,
+            done: true,
+            error: msg.error
+          });
+        }
+      }
+      return;
+    }
+
+    if(msg.id in state.runOnce) {
+      if(state.runOnce[msg.id].done) {
+        // already ran, notify worker immediately
+        worker.send({
+          type: 'bedrock.runOnceAsync',
+          id: msg.id,
+          done: true,
+          error: state.runOnce[msg.id].error
+        });
+      } else {
+        // still running, add worker ID to notify queue for later notification
+        state.runOnce[msg.id].notify.push(worker.id);
+      }
+      return;
+    }
+
+    // run in this worker
+    state.runOnce[msg.id] = {
+      worker: worker.id,
+      notify: [worker.id],
+      options: msg.options,
+      done: false,
+      error: null
+    };
+    worker.send({type: 'bedrock.runOnceAsync', id: msg.id, done: false});
   });
 }
 

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -260,12 +260,23 @@ api.runOnce = function(id, fn, options, callback) {
   process.send({type: 'bedrock.runOnce', id, options});
 };
 
+/**
+ * Called from a worker to executes the given function in only one worker.
+ *
+ * @param {string} id -  a unique identifier for the function to execute.
+ * @param {Function} fn - The async function to execute.
+ * @param {Object} [options={}] the options to use:
+ *          [allowOnRestart] true to allow this function to execute again,
+ *            but only once, on worker restart; this option is useful for
+ *            behavior that persists but should only run in a single worker.
+ *
+ * @returns {Promise} Resolves when the operation completes.
+ */
 api.runOnceAsync = async (id, fn, options = {}) => {
   const promise = new Promise((resolve, reject) => {
     // listen to run function once
     process.on('message', _runOnce);
 
-    // const ran = false;
     async function _runOnce(msg) {
       // ignore other messages
       if(!(_isMessageType(msg, 'bedrock.runOnceAsync') && msg.id === id)) {
@@ -279,9 +290,7 @@ api.runOnceAsync = async (id, fn, options = {}) => {
       }
 
       if(msg.done) {
-        // FIXME: what's going on with `ran`?
         return resolve();
-        // return resolve(msg.error, ran);
       }
 
       // run in this worker


### PR DESCRIPTION
I think trying to combine this with the existing callback version of this is needlessly complicated.

The FIXME related to `run` is due to my not understanding how it is used in the existing `runOnce` API since it appears to me that it is a `const` set to `false` and is never changed.