### PR TITLE
Fix variable used before it was declared.

### DIFF
--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -174,6 +174,7 @@ api.start = function(options, done) {
  * Called from workers to set the worker and master process user if it hasn't
  * already been set.
  */
+let _switchedProcessUser = false;
 api.setProcessUser = function() {
   if(_switchedProcessUser) {
     return;
@@ -190,7 +191,6 @@ api.setProcessUser = function() {
   // send message to master
   process.send({type: 'bedrock.switchProcessUser'});
 };
-let _switchedProcessUser = false;
 
 /**
  * Called from a worker to executes the given function in only one worker.


### PR DESCRIPTION
This bug dates back to a commit made to switch from `var` to `const`, `let`.  https://github.com/digitalbazaar/bedrock/commit/a71a9d947e0a79f738f34ff9762bfb1ea1a3373f

The _switchedProcessUser was being hoisted when `var` was in use, but not with `let`.  The current linting rules pointed out the error.