### PR TITLE
Fix run once

### DIFF
--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -222,14 +222,14 @@ api.runOnce = function(id, fn, options, callback) {
     if(!_isMessageType(msg, 'bedrock.runOnce') || msg.id !== id) {
       return;
     }
-
-    process.removeListener(messageEvent, runOnce);
-
+    // remove the listener if there is an error.
     if(msg.error) {
+      process.removeListener(messageEvent, runOnce);
       msg.error = errio.fromObject(msg.error, {stack: true});
     }
-
+    // remove the listener if it is done.
     if(msg.done) {
+      process.removeListener(messageEvent, runOnce);
       return callback(msg.error, ran);
     }
 
@@ -284,13 +284,13 @@ api.runOnceAsync = async (id, fn, options = {}) => {
         return;
       }
 
-      process.removeListener(messageEvent, _runOnce);
-
       if(msg.error) {
+        process.removeListener(messageEvent, _runOnce);
         return reject(errio.fromObject(msg.error, {stack: true}));
       }
 
       if(msg.done) {
+        process.removeListener(messageEvent, _runOnce);
         return resolve();
       }
 

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (c) 2012-2019 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
@@ -17,6 +17,7 @@ const pkginfo = require('pkginfo');
 const program = require('commander');
 const test = require('./test');
 const BedrockError = brUtil.BedrockError;
+const messageEvent = 'message';
 
 // core API
 const api = {};
@@ -213,7 +214,7 @@ api.runOnce = function(id, fn, options, callback) {
   options = options || {};
 
   // listen to run function once
-  process.on('message', runOnce);
+  process.addListener(messageEvent, runOnce);
 
   const ran = false;
   function runOnce(msg) {
@@ -222,7 +223,7 @@ api.runOnce = function(id, fn, options, callback) {
       return;
     }
 
-    process.removeListener('bedrock.runOnce', runOnce);
+    process.removeListener(messageEvent, runOnce);
 
     if(msg.error) {
       msg.error = errio.fromObject(msg.error, {stack: true});
@@ -275,7 +276,7 @@ api.runOnce = function(id, fn, options, callback) {
 api.runOnceAsync = async (id, fn, options = {}) => {
   const promise = new Promise((resolve, reject) => {
     // listen to run function once
-    process.on('message', _runOnce);
+    process.addListener(messageEvent, _runOnce);
 
     async function _runOnce(msg) {
       // ignore other messages
@@ -283,7 +284,7 @@ api.runOnceAsync = async (id, fn, options = {}) => {
         return;
       }
 
-      process.removeListener('bedrock.runOnceAsync', _runOnce);
+      process.removeListener(messageEvent, _runOnce);
 
       if(msg.error) {
         return reject(errio.fromObject(msg.error, {stack: true}));


### PR DESCRIPTION
Fix for https://github.com/digitalbazaar/bedrock/issues/45

Issued fixed:

1. Remove listener for runOnce & runOnceAsync events.
2. Only remove runOnce listeners if done or on error.
3. switch to `addListener` over `on` as `on` created confusion in the code. 

p.s. previously runOnceAsync was definitely running more than once you can add a logger in runOnceAsync on master and compare it to this.
p.p.s. please run this branch in your project.

this does not fix some of the bugs related to runOnceAsync we are running into, but it does generate more consistent possibly deterministic behavior from the functions.