### PR TITLE
Consolidate `runOnce` code, fix memory leak, remove extra message.

### DIFF
--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -8,6 +8,7 @@ const brUtil = require('./util');
 const cc = brUtil.config.main.computer();
 const cluster = require('cluster');
 const config = require('./config');
+const cycle = require('cycle');
 const errio = require('errio');
 const events = require('./events');
 const jsonld = require('./jsonld');
@@ -16,6 +17,7 @@ const path = require('path');
 const pkginfo = require('pkginfo');
 const program = require('commander');
 const test = require('./test');
+const {promisify} = require('util');
 const BedrockError = brUtil.BedrockError;
 
 // core API
@@ -211,53 +213,11 @@ api.runOnce = function(id, fn, options, callback) {
     options = {};
   }
   options = options || {};
-
-  // listen to run function once
-  process.on('message', runOnce);
-
-  const ran = false;
-  function runOnce(msg) {
-    // ignore other messages
-    if(!_isMessageType(msg, 'bedrock.runOnce') || msg.id !== id) {
-      return;
-    }
-
-    process.removeListener('bedrock.runOnce', runOnce);
-
-    if(msg.error) {
-      msg.error = errio.fromObject(msg.error, {stack: true});
-    }
-
-    if(msg.done) {
-      return callback(msg.error, ran);
-    }
-
-    const _callback = function(err) {
-      const _msg = {
-        type: 'bedrock.runOnce',
-        id,
-        done: true
-      };
-      if(err) {
-        _msg.error = errio.toObject(err, {stack: true});
-      }
-      process.send(_msg);
-    };
-
-    // run in this worker
-    if(fn.length > 0) {
-      return fn(_callback);
-    }
-    try {
-      fn();
-    } catch(e) {
-      return _callback(e);
-    }
-    _callback();
+  if(fn.length === 1) {
+    fn = promisify(fn);
   }
-
-  // schedule function to run
-  process.send({type: 'bedrock.runOnce', id, options});
+  _runOnce({type: 'bedrock.runOnce', id, fn, options})
+    .then(ran => callback(null, ran), callback);
 };
 
 /**
@@ -272,46 +232,8 @@ api.runOnce = function(id, fn, options, callback) {
  *
  * @returns {Promise} Resolves when the operation completes.
  */
-api.runOnceAsync = async (id, fn, options = {}) => {
-  const promise = new Promise((resolve, reject) => {
-    // listen to run function once
-    process.on('message', _runOnce);
-
-    async function _runOnce(msg) {
-      // ignore other messages
-      if(!(_isMessageType(msg, 'bedrock.runOnceAsync') && msg.id === id)) {
-        return;
-      }
-
-      process.removeListener('bedrock.runOnceAsync', _runOnce);
-
-      if(msg.error) {
-        return reject(errio.fromObject(msg.error, {stack: true}));
-      }
-
-      if(msg.done) {
-        return resolve();
-      }
-
-      // run in this worker
-      const _msg = {
-        type: 'bedrock.runOnceAsync',
-        id,
-        done: true
-      };
-      try {
-        await fn();
-      } catch(e) {
-        _msg.error = errio.toObject(e, {stack: true});
-      }
-      process.send(_msg);
-    } // end _runOnce
-  });
-
-  // schedule function to run
-  process.send({type: 'bedrock.runOnceAsync', id, options});
-  return promise;
-};
+api.runOnceAsync = async (id, fn, options = {}) =>
+  _runOnce({type: 'bedrock.runOnceAsync', id, fn, options});
 
 /**
  * Called from a worker to exit gracefully. Typically used by subcommands.
@@ -319,6 +241,55 @@ api.runOnceAsync = async (id, fn, options = {}) => {
 api.exit = function() {
   cluster.worker.kill();
 };
+
+async function _runOnce({type, id, fn, options}) {
+  // notify master to schedule work (if not already scheduled/run)
+  process.send({type, id, options});
+
+  // wait for scheduling result
+  let msg = await _waitForOneMessage({type, id});
+
+  // work completed in another worker, finish
+  if(msg.done) {
+    if(msg.error) {
+      throw errio.fromObject(msg.error, {stack: true});
+    }
+    return;
+  }
+
+  // run in this worker
+  msg = {type, id, done: true};
+  let error;
+  try {
+    await fn();
+  } catch(e) {
+    error = e;
+    msg.error = cycle.decycle(errio.toObject(e, {stack: true}));
+  }
+
+  // notify other workers that work is complete
+  process.send(msg);
+
+  if(error) {
+    throw error;
+  }
+}
+
+async function _waitForOneMessage({type, id}) {
+  // get coordinated message from master
+  return new Promise(resolve => {
+    // listen to run function once
+    process.on('message', _listenOnce);
+    function _listenOnce(msg) {
+      // ignore other messages
+      if(!(_isMessageType(msg, type) && msg.id === id)) {
+        return;
+      }
+      process.removeListener('message', _listenOnce);
+      resolve(msg);
+    }
+  });
+}
 
 function _parseCommandLine() {
   program.parse(process.argv);
@@ -649,9 +620,12 @@ function _startWorker(state, script) {
 
   // listen to schedule run once functions
   worker.on('message', function(msg) {
-    if(!_isMessageType(msg, 'bedrock.runOnce')) {
+    if(!(_isMessageType(msg, 'bedrock.runOnce') ||
+      _isMessageType(msg, 'bedrock.runOnceAsync'))) {
       return;
     }
+
+    const {type} = msg;
 
     if(msg.done) {
       state.runOnce[msg.id].done = true;
@@ -662,7 +636,7 @@ function _startWorker(state, script) {
         const id = notify.shift();
         if(id in cluster.workers) {
           cluster.workers[id].send({
-            type: 'bedrock.runOnce',
+            type,
             id: msg.id,
             done: true,
             error: msg.error
@@ -676,7 +650,7 @@ function _startWorker(state, script) {
       if(state.runOnce[msg.id].done) {
         // already ran, notify worker immediately
         worker.send({
-          type: 'bedrock.runOnce',
+          type,
           id: msg.id,
           done: true,
           error: state.runOnce[msg.id].error
@@ -691,63 +665,12 @@ function _startWorker(state, script) {
     // run in this worker
     state.runOnce[msg.id] = {
       worker: worker.id,
-      notify: [worker.id],
+      notify: [],
       options: msg.options,
       done: false,
       error: null
     };
-    worker.send({type: 'bedrock.runOnce', id: msg.id, done: false});
-  });
-
-  worker.on('message', function(msg) {
-    if(!_isMessageType(msg, 'bedrock.runOnceAsync')) {
-      return;
-    }
-
-    if(msg.done) {
-      state.runOnce[msg.id].done = true;
-      state.runOnce[msg.id].error = msg.error || null;
-      // notify workers to call callback
-      const notify = state.runOnce[msg.id].notify;
-      while(notify.length > 0) {
-        const id = notify.shift();
-        if(id in cluster.workers) {
-          cluster.workers[id].send({
-            type: 'bedrock.runOnceAsync',
-            id: msg.id,
-            done: true,
-            error: msg.error
-          });
-        }
-      }
-      return;
-    }
-
-    if(msg.id in state.runOnce) {
-      if(state.runOnce[msg.id].done) {
-        // already ran, notify worker immediately
-        worker.send({
-          type: 'bedrock.runOnceAsync',
-          id: msg.id,
-          done: true,
-          error: state.runOnce[msg.id].error
-        });
-      } else {
-        // still running, add worker ID to notify queue for later notification
-        state.runOnce[msg.id].notify.push(worker.id);
-      }
-      return;
-    }
-
-    // run in this worker
-    state.runOnce[msg.id] = {
-      worker: worker.id,
-      notify: [worker.id],
-      options: msg.options,
-      done: false,
-      error: null
-    };
-    worker.send({type: 'bedrock.runOnceAsync', id: msg.id, done: false});
+    worker.send({type, id: msg.id, done: false});
   });
 }
 


### PR DESCRIPTION
- Refactor `runOnce` calls to separate out listen once pattern
  from the rest of runOnce scheduling, etc.
- Use `async/await` to simplify code.

Replaces #48.