### PR TITLE
Update async-node-events and event handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - `emit` is now an async function and used instead of passing a callback for
     completion. User code **must** be updated for this change. It is suggested
     to await the `emit` calls and use async listeners or Promises.
+- Use master/worker child loggers.
 
 ### Removed
 - `bedrock.events.emit` wrapper. Using default from `async-node-events`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - `emit` is now an async function and used instead of passing a callback for
     completion. User code **must** be updated for this change. It is suggested
     to await the `emit` calls and use async listeners or Promises.
-- **BREAKING**: `runOnce` callback form is removed and replaced with the
+- **BREAKING**: `runOnce` callback form is removed in favor of the
   `runOnceAsync` implementation. `runOnceAsync` remains as an alias for
   `runOnce` but is deprecated. Quick fix is to wrap the new `runOnce` with
   `callbackify` and the `fn` param with `promisify`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # bedrock ChangeLog
 
 ### Changed
+- **BREAKING**: Update Node.js requirement to v10.12.0.
 - **BREAKING**: `bedrock.start()` now returns a promise instead of using a
   callback. Top-level code using the callback should change to `async`/`await`
   or `then`/`catch` as needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - `emit` is now an async function and used instead of passing a callback for
     completion. User code **must** be updated for this change. It is suggested
     to await the `emit` calls and use async listeners or Promises.
+- **BREAKING**: `runOnce` callback form is removed and replaced with the
+  `runOnceAsync` implementation. `runOnceAsync` remains as an alias for
+  `runOnce` but is deprecated. Quick fix is to wrap the new `runOnce` with
+  `callbackify` and the `fn` param with `promisify`.
 - Use master/worker child loggers.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # bedrock ChangeLog
 
+### Changed
+- **BREAKING**: `bedrock.start()` now returns a promise instead of using a
+  callback. Top-level code using the callback should change to `async`/`await`
+  or `then`/`catch` as needed.
+- **BREAKING**: Update `async-node-events` dependency and update events API.
+  - `emit` is now an async function and used instead of passing a callback for
+    completion. User code **must** be updated for this change. It is suggested
+    to await the `emit` calls and use async listeners or Promises.
+
+### Removed
+- `bedrock.events.emit` wrapper. Using default from `async-node-events`.
+- **BREAKING**: Deprecated event object style.
+
 ## 2.0.0 - 2019-10-22
 
 ### Changed

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -131,7 +131,7 @@ api.start = async (options) => {
   }
   // run
   if(cluster.isMaster) {
-    _runMaster(options);
+    _runMaster(startTime, options);
     // don't call callback in master process
     return;
   }
@@ -388,12 +388,8 @@ function _setupUncaughtExceptionHandler(mode, logger) {
   }
 }
 
-function _runMaster(options) {
-  // get starting script
-  const script = options.script || process.argv[1];
-
-  const logger = loggers.get('app');
-  logger.info('starting bedrock...');
+function _runMaster(startTime, options) {
+  const logger = loggers.get('app').child('bedrock/master');
 
   // setup cluster if running with istanbul coverage
   if(process.env.running_under_istanbul) {
@@ -413,8 +409,11 @@ function _runMaster(options) {
 
   _setupUncaughtExceptionHandler('master', logger);
 
-  logger.info('running bedrock master process "' +
-    config.core.master.title + '"', {pid: process.pid});
+  logger.info(
+    `starting process "${config.core.master.title}"`, {pid: process.pid});
+
+  // get starting script
+  const script = options.script || process.argv[1];
 
   // keep track of master state
   const masterState = {
@@ -435,14 +434,14 @@ function _runMaster(options) {
     // the process
     if(worker.exitedAfterDisconnect) {
       logger.info(
-        'worker ' + worker.process.pid + ' exited on purpose with code ' +
-        code + '; exiting master process.');
+        `worker "${worker.process.pid}" exited on purpose` +
+        ` with code "${code}"; exiting master process.`);
       process.exit(code);
     }
 
     // accidental worker exit (crash)
     logger.critical(
-      'worker ' + worker.process.pid + ' exited with code ' + code);
+      `worker "${worker.process.pid}" exited with code "${code}"`);
 
     // if configured, fork a replacement worker
     if(config.core.worker.restart) {
@@ -464,10 +463,11 @@ function _runMaster(options) {
   for(let i = 0; i < workers; ++i) {
     _startWorker(masterState, script);
   }
+  logger.info('started', {timeMs: Date.now() - startTime});
 }
 
 async function _runWorker(startTime) {
-  const logger = loggers.get('app');
+  const logger = loggers.get('app').child('bedrock/worker');
 
   // set 'ps' title
   const args = process.argv.slice(2).join(' ');
@@ -475,8 +475,7 @@ async function _runWorker(startTime) {
 
   _setupUncaughtExceptionHandler('worker', logger);
 
-  logger.info('running bedrock worker process "' +
-    config.core.worker.title + '"');
+  logger.info(`starting process "${config.core.worker.title}"`);
 
   // listen for master process exit
   let bedrockStarted = false;
@@ -511,10 +510,9 @@ async function _runWorker(startTime) {
   api.setProcessUser();
   await events.emit('bedrock.init');
   await events.emit('bedrock.start');
-  const dtTime = Date.now() - startTime;
-  logger.info('startup time: ' + dtTime + 'ms');
   await events.emit('bedrock.ready');
   await events.emit('bedrock.started');
+  logger.info('started', {timeMs: Date.now() - startTime});
 }
 
 function _startWorker(state, script) {

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -123,7 +123,7 @@ api.start = async (options) => {
   await events.emit('bedrock-loggers.init');
 
   try {
-    await promisify(loggers.init)();
+    await loggers.init();
   } catch(err) {
     // can't log, quit
     console.error('Failed to initialize logging system:', err);

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -14,7 +14,7 @@ const loggers = require('./loggers');
 const path = require('path');
 const pkginfo = require('pkginfo');
 const program = require('commander');
-const {promisify} = require('util');
+const {deprecate, promisify} = require('util');
 const {BedrockError} = brUtil;
 
 // core API
@@ -168,32 +168,6 @@ api.setProcessUser = function() {
 /**
  * Called from a worker to execute the given function in only one worker.
  *
- * @param id a unique identifier for the function to execute.
- * @param fn the function to execute; if it takes a parameter, it will be
- *          assumed to be a callback and `fn` will be executed asynchronously.
- * @param [options] the options to use:
- *          [allowOnRestart] true to allow this function to execute again,
- *            but only once, on worker restart; this option is useful for
- *            behavior that persists but should only run in a single worker.
- * @param callback(err, ran) called once the operation has completed in
- *          one worker.
- */
-api.runOnce = function(id, fn, options, callback) {
-  if(typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-  options = options || {};
-  if(fn.length === 1) {
-    fn = promisify(fn);
-  }
-  _runOnce({type: 'bedrock.runOnce', id, fn, options})
-    .then(ran => callback(null, ran), callback);
-};
-
-/**
- * Called from a worker to execute the given function in only one worker.
- *
  * @param {string} id -  a unique identifier for the function to execute.
  * @param {Function} fn - The async function to execute.
  * @param {Object} [options={}] the options to use:
@@ -203,17 +177,9 @@ api.runOnce = function(id, fn, options, callback) {
  *
  * @returns {Promise} Resolves when the operation completes.
  */
-api.runOnceAsync = async (id, fn, options = {}) =>
-  _runOnce({type: 'bedrock.runOnceAsync', id, fn, options});
+api.runOnce = async (id, fn, options = {}) => {
+  const type = 'bedrock.runOnce';
 
-/**
- * Called from a worker to exit gracefully. Typically used by subcommands.
- */
-api.exit = function() {
-  cluster.worker.kill();
-};
-
-async function _runOnce({type, id, fn, options}) {
   // notify master to schedule work (if not already scheduled/run)
   process.send({type, id, options});
 
@@ -245,6 +211,19 @@ async function _runOnce({type, id, fn, options}) {
     throw error;
   }
 }
+
+/**
+ * **DEPRECATED**: runOnceAsync() is deprecated. Use runOnce() instead.
+ */
+api.runOnceAsync = deprecate(
+  api.runOnce, 'runOnceAsync() is deprecated. Use runOnce() instead.');
+
+/**
+ * Called from a worker to exit gracefully. Typically used by subcommands.
+ */
+api.exit = function() {
+  cluster.worker.kill();
+};
 
 async function _waitForOneMessage({type, id}) {
   // get coordinated message from master
@@ -569,8 +548,7 @@ function _startWorker(state, script) {
 
   // listen to schedule run once functions
   worker.on('message', function(msg) {
-    if(!(_isMessageType(msg, 'bedrock.runOnce') ||
-      _isMessageType(msg, 'bedrock.runOnceAsync'))) {
+    if(!_isMessageType(msg, 'bedrock.runOnce')) {
       return;
     }
 

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -361,7 +361,7 @@ function _setupUncaughtExceptionHandler(mode, logger) {
   if(config.cli.command.name() !== 'test') {
     process.on('uncaughtException', function(err) {
       process.removeAllListeners('uncaughtException');
-      logger.critical(mode + ': uncaught error:', err);
+      logger.critical(mode + ': uncaught error:', {error: err});
       process.exit(1);
     });
   }

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -3,7 +3,6 @@
  */
 'use strict';
 
-const async = require('async');
 const brUtil = require('./util');
 const cc = brUtil.config.main.computer();
 const cluster = require('cluster');
@@ -78,14 +77,11 @@ api.program = program.version(api.version);
  * @param options the options to use:
  *          [script] the script to execute when forking bedrock workers, by
  *            default this will be process.argv[1].
- * @param done(err) called by bedrock workers once the bedrock application has
- *          started or once an error has occured.
+ *
+ * @returns {Promise} Resolves when the application has started or an error has
+ *            occured.
  */
-api.start = function(options, done) {
-  if(typeof options === 'function') {
-    done = options;
-    options = null;
-  }
+api.start = async (options) => {
   options = options || {};
 
   const startTime = Date.now();
@@ -117,54 +113,34 @@ api.start = function(options, done) {
     .option('--workers <num>',
       'The number of workers to use (0: # of cpus).', parseInt);
 
-  async.auto({
-    beforeInit: function(callback) {
-      events.emit('bedrock-cli.init', callback);
-    },
-    cliParse: ['beforeInit', function(results, callback) {
-      _parseCommandLine();
-      events.emit('bedrock-cli.parsed', callback);
-    }],
-    init: ['cliParse', function(results, callback) {
-      _loadConfigs();
-      _configureLoggers();
-      _configureWorkers();
-      _configureProcess();
-      events.emit('bedrock-loggers.init', callback);
-    }],
-    initLoggers: ['init', function(results, callback) {
-      loggers.init(function(err) {
-        if(err) {
-          // can't log, quit
-          console.error('Failed to initialize logging system:', err);
-          process.exit(1);
-        }
-        callback();
-      });
-    }],
-    run: ['initLoggers', function(results, callback) {
-      if(cluster.isMaster) {
-        _runMaster(options);
-        // don't call callback in master process
-        return;
-      }
-      _runWorker(startTime, function(err) {
-        if(err) {
-          return events.emit('bedrock.error', err, function() {
-            callback(err);
-          });
-        }
-        callback();
-      });
-    }]
-  }, function(err) {
-    if(done) {
-      return done(err);
-    }
-    if(err) {
-      throw err;
-    }
-  });
+  await events.emit('bedrock-cli.init');
+  _parseCommandLine();
+  await events.emit('bedrock-cli.parsed');
+  _loadConfigs();
+  _configureLoggers();
+  _configureWorkers();
+  _configureProcess();
+  await events.emit('bedrock-loggers.init');
+
+  try {
+    await promisify(loggers.init)();
+  } catch(err) {
+    // can't log, quit
+    console.error('Failed to initialize logging system:', err);
+    process.exit(1);
+  }
+  // run
+  if(cluster.isMaster) {
+    _runMaster(options);
+    // don't call callback in master process
+    return;
+  }
+  try {
+    await _runWorker(startTime);
+  } catch(err) {
+    await events.emit('bedrock.error', err);
+    throw err;
+  }
 };
 
 /**
@@ -490,7 +466,7 @@ function _runMaster(options) {
   }
 }
 
-function _runWorker(startTime, done) {
+async function _runWorker(startTime) {
   const logger = loggers.get('app');
 
   // set 'ps' title
@@ -510,55 +486,35 @@ function _runWorker(startTime, done) {
     }
 
     if(!bedrockStarted) {
-      return events.emit('bedrock-cli.exit', function() {
+      return events.emit('bedrock-cli.exit').finally(() => {
         process.exit();
       });
     }
 
-    events.emit('bedrock.stop', function(err) {
-      if(err) {
-        throw err;
-      }
-      events.emit('bedrock-cli.exit', function() {
+    return events.emit('bedrock.stop').then(() => {
+      return events.emit('bedrock-cli.exit').finally(() => {
         process.exit();
       });
     });
   });
 
-  async.auto({
-    cliReady: function(callback) {
-      events.emit('bedrock-cli.ready', callback);
-    },
-    configure: ['cliReady', function(results, callback) {
-      if(results.cliReady === false) {
-        // skip default behavior (do not emit bedrock core events)
-        return done();
-      }
-      bedrockStarted = true;
-      events.emit('bedrock.configure', callback);
-    }],
-    adminInit: ['configure', function(results, callback) {
-      events.emit('bedrock.admin.init', callback);
-    }],
-    init: ['adminInit', function(results, callback) {
-      // set process user
-      api.setProcessUser();
-      events.emit('bedrock.init', callback);
-    }],
-    start: ['init', function(results, callback) {
-      events.emit('bedrock.start', callback);
-    }],
-    ready: ['start', function(results, callback) {
-      const dtTime = Date.now() - startTime;
-      logger.info('startup time: ' + dtTime + 'ms');
-      events.emit('bedrock.ready', callback);
-    }],
-    started: ['ready', function(results, callback) {
-      events.emit('bedrock.started', callback);
-    }]
-  }, function(err) {
-    done(err);
-  });
+  const cliReady = await events.emit('bedrock-cli.ready');
+  // skip default behavior if cancelled (do not emit bedrock core events)
+  // used for CLI commands
+  if(cliReady === false) {
+    return;
+  }
+  bedrockStarted = true;
+  await events.emit('bedrock.configure');
+  await events.emit('bedrock.admin.init');
+  // set process user
+  api.setProcessUser();
+  await events.emit('bedrock.init');
+  await events.emit('bedrock.start');
+  const dtTime = Date.now() - startTime;
+  logger.info('startup time: ' + dtTime + 'ms');
+  await events.emit('bedrock.ready');
+  await events.emit('bedrock.started');
 }
 
 function _startWorker(state, script) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -3,113 +3,24 @@
  */
 'use strict';
 
-const events = {
-  EventEmitter: require('async-node-events')
-};
+const {EventEmitter} = require('async-node-events');
 
-const api = new events.EventEmitter();
+const api = new EventEmitter();
 api.setMaxListeners(0);
 api.removeAllListeners('maxListenersPassed');
 module.exports = api;
 
-// store original emit function
-const emit = api.emit;
-
-/**
- * Emits an event just like the standard EventEmitter does, however, if the
- * last parameter passed is a function, it is assumed to be a callback that
- * will be called once the event has propagated to all listeners or it has
- * been canceled due to an error.
- *
- * Note that this module also permits listeners to be executed asynchronously.
- * Any asynchronous listeners will be notified of an event in order of
- * registration. Each listener will block the next listener to receive the
- * event until the callback that is passed to it is called. If an error is
- * passed as the first parameter to the callback, then the event will be
- * canceled.
- *
- * Backwards-compatibility support exists for the deprecated method of passing
- * the first argument as an object with a 'type' property that indicates the
- * event type.
- *
- * So two forms are available:
- * * The standard emit() usage of an event type and an arbitrary number of
- *   arguments.
- * * DEPRECATED: A single event object argument with the following fields:
- *     type: event type (string)
- *     time: event time (Date, optional, added if omitted)
- *     details: event details (object)
- *
- * @return a Promise that resolves to undefined once the event has been emitted
- *         to all listeners (or to `false` if it was canceled).
- */
-api.emit = function(event /* ... */) {
-  let args;
-  // check for event object
-  if(typeof event === 'object' && event.type) {
-    // add time if not present
-    event.time = event.time || new Date();
-    args = [event.type, event];
-  } else {
-    // otherwise assume regular emit call
-    args = Array.prototype.slice.call(arguments);
-  }
-
-  // default callback
-  let callback = () => {};
-  // the second conditional here is designed to differentiate functions like
-  // bedrock-express `server` from an actual callback function
-  if(typeof args[args.length - 1] === 'function' &&
-    Object.keys(args[args.length - 1]).length === 0) {
-    // save `callback` to call once `emit` completes
-    callback = args[args.length - 1];
-    args.pop();
-  }
-
-  // call callback that resolves promise
-  const deferred = {};
-  const promise = new Promise((resolve, reject) => {
-    deferred.resolve = resolve;
-    deferred.reject = reject;
-  });
-  args.push((err, result) => {
-    if(err) {
-      deferred.reject(err);
-    } else {
-      deferred.resolve(result);
-    }
-    callback(err, result);
-  });
-
-  // emit
-  emit.apply(api, args);
-  return promise;
-};
-
 /**
  * Schedules an event to be emitted on the next tick (via process.nextTick).
  *
- * Backwards-compatibility support exists for the deprecated method of passing
- * the first argument as an object with a 'type' property that indicates the
- * event type.
- *
- * So two forms are available:
- * * The standard emit() usage of an event type and an arbitrary number of
- *   arguments.
- * * DEPRECATED: A single event object argument with the following fields:
- *     type: event type (string)
- *     time: event time (Date, optional, added if omitted)
- *     details: event details (object)
- *
  * @return a Promise that resolves to undefined once the event has been emitted
  *         to all listeners (or to `false` if it was canceled).
  */
-api.emitLater = function(/* ... */) {
+api.emitLater = function(...args) {
   // emit asynchronously
-  const args = arguments;
   return new Promise((resolve, reject) => {
     process.nextTick(() => {
-      api.emit.apply(api, args).then(resolve, reject);
+      api.emit(...args).then(resolve, reject);
     });
   });
 };

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -3,14 +3,12 @@
  */
 'use strict';
 
-const async = require('async');
 const brUtil = require('./util');
 const cc = brUtil.config.main.computer();
 const cluster = require('cluster');
 const config = require('./config');
 const cycle = require('cycle');
-const fs = require('fs');
-const mkdirp = require('mkdirp');
+const fs = require('fs').promises;
 const path = require('path');
 const util = require('util');
 const winston = require('winston');
@@ -98,7 +96,7 @@ if(cluster.isMaster) {
   };
 }
 
-function chown(filename, callback) {
+async function chown(filename) {
   if(config.core.running.userId) {
     let uid = config.core.running.userId;
     if(typeof uid !== 'number') {
@@ -110,20 +108,19 @@ function chown(filename, callback) {
         user = {uid: process.getuid()};
       }
       if(!user && !posix && typeof uid !== 'number') {
-        return callback(new Error(
+        throw new Error(
           '"posix" package not available to convert user "' + uid + '" ' +
-          'to a number. Try using a uid number instead.'));
+          'to a number. Try using a uid number instead.');
       }
       if(!user) {
-        return callback(new Error('No system user id for "' + uid + '".'));
+        throw new Error('No system user id for "' + uid + '".');
       }
       uid = user.uid;
     }
     if(process.getgid) {
-      return fs.chown(filename, uid, process.getgid(), callback);
+      await fs.chown(filename, uid, process.getgid());
     }
   }
-  callback();
 }
 
 // class to handle pretty printing module name
@@ -178,10 +175,8 @@ class ModuleFileTransport extends winston.transports.File {
 
 /**
  * Initializes the logging system.
- *
- * @param callback(err) called once the operation completes.
  */
-container.init = function(callback) {
+container.init = async () => {
   if(cluster.isMaster) {
     // create shared transports
     const transports = container.transports;
@@ -196,75 +191,65 @@ container.init = function(callback) {
     transports.access.name = 'access';
     transports.error.name = 'error';
 
-    async.waterfall([
-      function(callback) {
-        // ensure all files are created and have ownership set to the
-        // application process user
-        const fileLoggers = Object.keys(config.loggers).filter(function(name) {
-          const logger = config.loggers[name];
-          return (brUtil.isObject(logger) && 'filename' in logger);
-        }).map(function(name) {
-          return config.loggers[name];
-        });
-        async.each(fileLoggers, function(fileLogger, callback) {
-          const dirname = path.dirname(fileLogger.filename);
-          async.waterfall([
-            // make directory and chown if requested
-            async.apply(mkdirp.mkdirp, dirname),
-            function(made, callback) {
-              if('bedrock' in fileLogger && fileLogger.bedrock.enableChownDir) {
-                return chown(dirname, callback);
-              }
-              callback();
-            },
-            // check file can be opened
-            async.apply(fs.open, fileLogger.filename, 'a'),
-            async.apply(fs.close),
-            // always chown log file
-            async.apply(chown, fileLogger.filename)
-          ], callback);
-        }, callback);
-      },
-      function(callback) {
-        // create master loggers
-        for(const cat in config.loggers.categories) {
-          const transportNames = config.loggers.categories[cat];
-          const options = {transports: []};
-          transportNames.forEach(function(name) {
-            options.transports.push(transports[name]);
-          });
-          const logger = new winston.Logger(options);
-          logger.setLevels(levels);
-          if(container.loggers[cat]) {
-            container.loggers[cat].__proto__ = logger;
-          } else {
-            const wrapper = {};
-            wrapper.__proto__ = logger;
-            container.loggers[cat] = wrapper;
-          }
-        }
-
-        // set the colors to use on the console
-        winston.addColors(colors);
-
-        /**
-         * Attaches a message handler to the given worker. This should be
-         * called by the master process to handle worker log messages.
-         *
-         * @param worker the worker to attach the message handler to.
-         */
-        container.attach = function(worker) {
-          // set up message handler for master process
-          worker.on('message', function(msg) {
-            if(typeof msg === 'object' && msg.type === 'bedrock.logger') {
-              container.get(msg.category).log(msg.level, msg.msg, msg.meta);
-            }
-          });
-        };
-
-        callback();
+    // ensure all files are created and have ownership set to the
+    // application process user
+    const fileLoggers = Object.keys(config.loggers).filter(function(name) {
+      const logger = config.loggers[name];
+      return (brUtil.isObject(logger) && 'filename' in logger);
+    }).map(function(name) {
+      return config.loggers[name];
+    });
+    // TODO: run in parallel
+    for(const fileLogger of fileLoggers) {
+      const dirname = path.dirname(fileLogger.filename);
+      // make directory and chown if requested
+      await fs.mkdir(dirname, {recursive: true});
+      if('bedrock' in fileLogger && fileLogger.bedrock.enableChownDir) {
+        await chown(dirname);
       }
-    ], callback);
+      // check file can be opened
+      const f = await fs.open(fileLogger.filename, 'a');
+      await f.close();
+      // always chown log file
+      await chown(fileLogger.filename);
+    }
+
+    // create master loggers
+    for(const cat in config.loggers.categories) {
+      const transportNames = config.loggers.categories[cat];
+      const options = {transports: []};
+      transportNames.forEach(function(name) {
+        options.transports.push(transports[name]);
+      });
+      const logger = new winston.Logger(options);
+      logger.setLevels(levels);
+      if(container.loggers[cat]) {
+        container.loggers[cat].__proto__ = logger;
+      } else {
+        const wrapper = {};
+        wrapper.__proto__ = logger;
+        container.loggers[cat] = wrapper;
+      }
+    }
+
+    // set the colors to use on the console
+    winston.addColors(colors);
+
+    /**
+     * Attaches a message handler to the given worker. This should be
+     * called by the master process to handle worker log messages.
+     *
+     * @param worker the worker to attach the message handler to.
+     */
+    container.attach = function(worker) {
+      // set up message handler for master process
+      worker.on('message', function(msg) {
+        if(typeof msg === 'object' && msg.type === 'bedrock.logger') {
+          container.get(msg.category).log(msg.level, msg.msg, msg.meta);
+        }
+      });
+    };
+
     return;
   }
 
@@ -363,8 +348,6 @@ container.init = function(callback) {
 
   // set the colors to use on the console
   winston.addColors(colors);
-
-  callback();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock",
   "dependencies": {
-    "async-node-events": "github:digitalbazaar/async-node-events#promises",
+    "async-node-events": "^2.0.0",
     "commander": "^2.14.1",
     "cycle": "^1.0.3",
     "delay": "^4.1.0",
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "eslint": "^6.0.1",
-    "eslint-config-digitalbazaar": "^2.0.0"
+    "eslint-config-digitalbazaar": "^2.0.1"
   },
   "engines": {
     "node": ">=10.12.0"

--- a/package.json
+++ b/package.json
@@ -26,14 +26,12 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock",
   "dependencies": {
-    "async": "^2.6.0",
     "async-node-events": "github:digitalbazaar/async-node-events#promises",
     "commander": "^2.14.1",
     "cycle": "^1.0.3",
     "delay": "^4.1.0",
     "errio": "^1.2.2",
     "lodash": "^4.17.14",
-    "mkdirp": "~0.5.0",
     "nyc": "^14.1.1",
     "pkginfo": "^0.4.1",
     "uuid-random": "^1.0.6",
@@ -48,7 +46,7 @@
     "eslint-config-digitalbazaar": "^2.0.0"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10.12.0"
   },
   "main": "./lib/bedrock"
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/digitalbazaar/bedrock",
   "dependencies": {
     "async": "^2.6.0",
-    "async-node-events": "^1.0.0",
+    "async-node-events": "github:digitalbazaar/async-node-events#promises",
     "commander": "^2.14.1",
     "cycle": "^1.0.3",
     "delay": "^4.1.0",


### PR DESCRIPTION
- start() now returns a Promise instead of using a callback.
- async-node-events updated.
- Updated for new events API.
- Remove old event object style.