### PR TITLE
Add console.error logging on worker init failure.

### DIFF
--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -138,6 +138,7 @@ api.start = async options => {
   try {
     await _runWorker(startTime);
   } catch(err) {
+    console.error('An error occurred during worker initialization.', err);
     await events.emit('bedrock.error', err);
     throw err;
   }


### PR DESCRIPTION
not quite sure what the existing `await events.emit('bedrock.error', err);` is doing or is supposed to do, but bedrock is not surfacing worker initialization failures in a meaningful way.  Not on the console anyway.  This addresses that problem.

In my particular case, a module was not happy with the configs and threw during its `ready` handler which was resulting in the worker existing with exit code 1 without any additional information.