### PR TITLE
Ensure `defaultMeta` is always included when logging.

### DIFF
--- a/lib/loggers/WorkerTransport.js
+++ b/lib/loggers/WorkerTransport.js
@@ -3,6 +3,7 @@
  */
 'use strict';
 
+const cycle = require('cycle');
 const Transport = require('winston-transport');
 
 module.exports = class WorkerTransport extends Transport {
@@ -14,6 +15,20 @@ module.exports = class WorkerTransport extends Transport {
   }
 
   log(info, callback) {
+    for(const key in info) {
+      const value = info[key];
+      // convert errors into objects
+      if(value instanceof Error) {
+        info[key] = {
+          message: value.message,
+          stack: value.stack,
+          ...cycle.decycle(value)
+        };
+      } else {
+        // decycle all other values
+        info[key] = cycle.decycle(value);
+      }
+    }
     info.workerId = this.workerId;
     info.workerPid = process.pid;
 

--- a/lib/loggers/index.js
+++ b/lib/loggers/index.js
@@ -60,21 +60,30 @@ container.add = function(id) {
   if(!existing) {
     const wrapper = Object.create(logger);
     wrapper.log = function(level, msg, ...meta) {
+      // get default meta to ensure it is always applied
+      const {defaultMeta} = this;
+      // use `Object.getPrototypeOf` because the prototype may change
+      // while the logging subsystem initializes
+      const log = Object.getPrototypeOf(wrapper).log;
       if(arguments.length === 1) {
-        return Object.getPrototypeOf(wrapper).log.apply(
-          wrapper, [level]);
+        return log.apply(wrapper, [{...defaultMeta, ...level}]);
       }
-      return Object.getPrototypeOf(wrapper).log.apply(
-        wrapper, [level, msg, ...meta]);
+      if(meta.length === 0) {
+        meta.push({defaultMeta});
+      } else {
+        meta[0] = {...defaultMeta, ...meta[0]};
+      }
+      return log.apply(wrapper, [level, msg, ...meta]);
     };
-    wrapper.child = function(childMeta) {
+    const createChild = wrapper.child;
+    wrapper.child = function(childMeta, ...args) {
       // simple string name is shortcut for {module: name}
       if(typeof childMeta === 'string') {
         childMeta = {module: childMeta};
       }
-      // create child logger with merged meta data from parent
-      const child = Object.create(this);
-      child.defaultMeta = {...this.defaultMeta, ...childMeta};
+      // create child logger from wrapper and merge child meta into parent meta
+      const child = createChild.apply(wrapper, [childMeta, ...args]);
+      child.defaultMeta = {...wrapper.defaultMeta, ...childMeta};
       return child;
     };
     logger = wrapper;


### PR DESCRIPTION
- Decycle "info" and include error properties `message` and
  `stack` that must be copied manually when sending messages
  between processes in the WorkerTransport.