### PR TITLE
Fix exit flow to include proper exit code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # bedrock ChangeLog
 
+## 4.4.3 - 2021-12-xx
+
+### Fixed
+- Ensure primary process does not exit before logger completes or errors so
+  that the proper error code is returned.
+- Ensure an orderly exit is performed when nothing else is scheduled to
+  run on the event loop on the primary process.
+
 ## 4.4.2 - 2021-11-04
 
 ### Fixed

--- a/lib/bedrock.js
+++ b/lib/bedrock.js
@@ -459,9 +459,8 @@ function _runPrimary(startTime, options) {
   // get starting script
   const script = options.script || process.argv[1];
 
-  // the first time `process.exit()` is called on the primary, attempt to do
-  // an orderly exit
-  process.once('exit', async function() {
+  // if nothing else is scheduled on the event loop, attempt an orderly exit
+  process.once('beforeExit', async function() {
     await _exit();
   });
 
@@ -781,10 +780,10 @@ async function _logExit(code = 0) {
   try {
     const p = new Promise(resolve => {
       logger.info(
-        `${logPrefix} primary process exiting with code "${code}".`, {code},
-        () => {
-          resolve();
-        });
+        `${logPrefix} primary process exiting with code "${code}".`, {code});
+      logger.once('finish', () => resolve());
+      logger.once('error', () => resolve());
+      logger.end();
     });
     await p;
   } finally {}


### PR DESCRIPTION
Passing a callback to the logger to schedule a promise to resolve
was not working (the logger API confusingly doesn't accept a callback,
only the logger transport API does). To wait for the logger to
complete and properly schedule code to run to resolve the promise,
the logger streaming API was used instead.

Additionally, async code cannot run on the `exit` event for the
primary process; this was noticed during this fix and remedied
to run on `beforeExit` instead in the case that nothing is
scheduled on the event loop.