### PR TITLE
Move eslint plugin to `devDependencies`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # `@bedrock/core` ChangeLog
 
+## 6.1.3 - 2024-03-xx
+
+### Fixed
+- Move eslint plugin to `devDependencies`.
+
 ## 6.1.2 - 2024-02-28
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@digitalbazaar/async-node-events": "^3.0.0",
     "commander": "^9.2.0",
     "cycle": "^1.0.3",
-    "eslint-plugin-unicorn": "^51.0.1",
     "fast-safe-stringify": "^2.1.1",
     "serialize-error": "^10.0.0",
     "triple-beam": "^1.3.0",
@@ -40,6 +39,7 @@
     "eslint": "^8.57.0",
     "eslint-config-digitalbazaar": "^5.0.1",
     "eslint-plugin-jsdoc": "^48.2.0",
+    "eslint-plugin-unicorn": "^51.0.1",
     "jsdoc": "^4.0.2",
     "jsdoc-to-markdown": "^8.0.1"
   },


### PR DESCRIPTION
This appears to be a mistake introduced in:
https://github.com/digitalbazaar/bedrock/commit/275888b155400568be96679ce9d635f3181b2ce3