### PR TITLE
Replace unmaintained `uid-number` package with `passwd-user`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,8 @@ jobs:
         cd test
         npm run coverage-ci
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: ./test/coverage/lcov.info
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # `@bedrock/core` ChangeLog
 
-## 6.1.4 - 2024-10-dd
+## 6.2.0 - 2024-10-dd
+
+### Changed
+- Use `serialize-error@11`. No significant changes are expected.
 
 ### Fixed
 - Replace unmaintained `uid-number` package with `passwd-user`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # `@bedrock/core` ChangeLog
 
+## 6.1.4 - 2024-10-dd
+
+### Fixed
+- Replace unmaintained `uid-number` package with `passwd-user`.
+
 ## 6.1.3 - 2024-03-06
 
 ### Fixed

--- a/lib/loggers/fileLogger.js
+++ b/lib/loggers/fileLogger.js
@@ -19,13 +19,11 @@ import * as brUtil from '../util.js';
 import * as formatters from './formatters.js';
 import {config} from '../config.js';
 import {promises as fs} from 'node:fs';
+import {passwdUser} from 'passwd-user';
 import path from 'node:path';
-import {promisify} from 'node:util';
-import uidNumber from 'uid-number';
 import winston from 'winston';
 
 const cc = brUtil.config.main.computer();
-const getUserId = promisify(uidNumber);
 
 // config filenames
 // configured here instead of config.js due to util dependency issues
@@ -89,7 +87,7 @@ async function _chown(filename) {
       uid = process.getuid();
     } else {
       try {
-        uid = await getUserId(uid);
+        ({userIdentifier: uid} = await passwdUser(uid));
       } catch(e) {
         throw new brUtil.BedrockError(
           `Unable to convert user "${uid}" to a numeric user id. ` +

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cycle": "^1.0.3",
     "fast-safe-stringify": "^2.1.1",
     "passwd-user": "^4.0.0",
-    "serialize-error": "^10.0.0",
+    "serialize-error": "^11.0.3",
     "triple-beam": "^1.3.0",
     "winston": "^3.7.2",
     "winston-transport": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -29,19 +29,19 @@
     "commander": "^9.2.0",
     "cycle": "^1.0.3",
     "fast-safe-stringify": "^2.1.1",
+    "passwd-user": "^4.0.0",
     "serialize-error": "^10.0.0",
     "triple-beam": "^1.3.0",
-    "uid-number": "^0.0.6",
     "winston": "^3.7.2",
     "winston-transport": "^4.5.0"
   },
   "devDependencies": {
     "eslint": "^8.57.0",
     "eslint-config-digitalbazaar": "^5.0.1",
-    "eslint-plugin-jsdoc": "^48.2.0",
-    "eslint-plugin-unicorn": "^51.0.1",
+    "eslint-plugin-jsdoc": "^50.4.1",
+    "eslint-plugin-unicorn": "^56.0.0",
     "jsdoc": "^4.0.2",
-    "jsdoc-to-markdown": "^8.0.1"
+    "jsdoc-to-markdown": "^9.0.2"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
I would also like to update the `serialize-error` package. It has a new major version with this changelog that I don't expect to affect us:

https://github.com/sindresorhus/serialize-error/releases/tag/v11.0.0

@mattcollier, please let me know if you think I can roll that update in.

EDIT: I manually tested the new username => UID code path here. We don't have a good built-in test for this -- and I'm not sure how to write one that will work across systems either (not taking on figuring that out either at the moment).